### PR TITLE
added 'force' option to disable suspicious changes warnings

### DIFF
--- a/sacred/commandline_options.py
+++ b/sacred/commandline_options.py
@@ -159,3 +159,12 @@ class UnobservedOption(CommandLineOption):
     def apply(cls, args, run):
         """Set this run to unobserved mode."""
         run.unobserved = True
+
+
+class DisableSuspiciousChangesWarningsOption(CommandLineOption):
+    """Disable warnings about suspicious changes for this run."""
+
+    @classmethod
+    def apply(cls, args, run):
+        """Set this run to not warn about suspicous changes."""
+        run.disable_suspicious_changes_warnings = True

--- a/sacred/commandline_options.py
+++ b/sacred/commandline_options.py
@@ -161,10 +161,10 @@ class UnobservedOption(CommandLineOption):
         run.unobserved = True
 
 
-class DisableSuspiciousChangesWarningsOption(CommandLineOption):
+class ForceOption(CommandLineOption):
     """Disable warnings about suspicious changes for this run."""
 
     @classmethod
     def apply(cls, args, run):
         """Set this run to not warn about suspicous changes."""
-        run.disable_suspicious_changes_warnings = True
+        run.force = True

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -8,7 +8,7 @@ import sys
 from collections import OrderedDict
 
 from sacred.arg_parser import get_config_updates, parse_args
-from sacred.commandline_options import gather_command_line_options
+from sacred.commandline_options import gather_command_line_options, DisableSuspiciousChangesWarningsOption
 from sacred.commands import print_config, print_dependencies
 from sacred.ingredient import Ingredient
 from sacred.utils import print_filtered_stacktrace
@@ -125,8 +125,11 @@ class Experiment(Ingredient):
         :returns: the Run object corresponding to the finished run
         :rtype: sacred.run.Run
         """
+        disable_suspicious_changes_warnings_flag = '--' + DisableSuspiciousChangesWarningsOption.get_flag()[1]
+        disable_suspicious_changes_warnings = args[disable_suspicious_changes_warnings_flag] if disable_suspicious_changes_warnings_flag in args else False
+
         run = self._create_run_for_command(command_name, config_updates,
-                                           named_configs)
+                                           named_configs, disable_suspicious_changes_warnings=disable_suspicious_changes_warnings)
         self.current_run = run
 
         for option in gather_command_line_options():

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -8,7 +8,7 @@ import sys
 from collections import OrderedDict
 
 from sacred.arg_parser import get_config_updates, parse_args
-from sacred.commandline_options import gather_command_line_options, DisableSuspiciousChangesWarningsOption
+from sacred.commandline_options import gather_command_line_options, ForceOption
 from sacred.commands import print_config, print_dependencies
 from sacred.ingredient import Ingredient
 from sacred.utils import print_filtered_stacktrace
@@ -125,11 +125,11 @@ class Experiment(Ingredient):
         :returns: the Run object corresponding to the finished run
         :rtype: sacred.run.Run
         """
-        disable_suspicious_changes_warnings_flag = '--' + DisableSuspiciousChangesWarningsOption.get_flag()[1]
-        disable_suspicious_changes_warnings = args[disable_suspicious_changes_warnings_flag] if disable_suspicious_changes_warnings_flag in args else False
+        force_flag = '--' + ForceOption.get_flag()[1]
+        force = args[force_flag] if force_flag in args else False
 
         run = self._create_run_for_command(command_name, config_updates,
-                                           named_configs, disable_suspicious_changes_warnings=disable_suspicious_changes_warnings)
+                                           named_configs, force=force)
         self.current_run = run
 
         for option in gather_command_line_options():

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -304,7 +304,7 @@ class Ingredient(object):
     # ======================== Private Helpers ================================
 
     def _create_run_for_command(self, command_name, config_updates=None,
-                                named_configs=(), disable_suspicious_changes_warnings=False):
+                                named_configs=(), force=False):
         run = create_run(self, command_name, config_updates,
-                         named_configs=named_configs, disable_suspicious_changes_warnings=disable_suspicious_changes_warnings)
+                         named_configs=named_configs, force=force)
         return run

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -304,7 +304,7 @@ class Ingredient(object):
     # ======================== Private Helpers ================================
 
     def _create_run_for_command(self, command_name, config_updates=None,
-                                named_configs=()):
+                                named_configs=(), disable_suspicious_changes_warnings=False):
         run = create_run(self, command_name, config_updates,
-                         named_configs=named_configs)
+                         named_configs=named_configs, disable_suspicious_changes_warnings=disable_suspicious_changes_warnings)
         return run

--- a/sacred/initialize.py
+++ b/sacred/initialize.py
@@ -159,7 +159,8 @@ class Scaffold(object):
             cfunc.rnd = create_rnd(seed)
             cfunc.run = run
 
-        self._warn_about_suspicious_changes()
+        if not run.disable_suspicious_changes_warnings:
+            self._warn_about_suspicious_changes()
 
     def _warn_about_suspicious_changes(self):
         for add in sorted(self.config_mods.added):
@@ -281,7 +282,7 @@ def get_command(scaffolding, command_path):
 
 
 def create_run(experiment, command_name, config_updates=None,
-               named_configs=()):
+               named_configs=(), disable_suspicious_changes_warnings=False):
 
     sorted_ingredients = gather_ingredients_topological(experiment)
     scaffolding = create_scaffolding(experiment, sorted_ingredients)
@@ -325,6 +326,8 @@ def create_run(experiment, command_name, config_updates=None,
 
     if hasattr(main_function, 'unobserved'):
         run.unobserved = main_function.unobserved
+
+    run.disable_suspicious_changes_warnings = disable_suspicious_changes_warnings
 
     for scaffold in scaffolding.values():
         scaffold.finalize_initialization(run=run)

--- a/sacred/initialize.py
+++ b/sacred/initialize.py
@@ -159,7 +159,7 @@ class Scaffold(object):
             cfunc.rnd = create_rnd(seed)
             cfunc.run = run
 
-        if not run.disable_suspicious_changes_warnings:
+        if not run.force:
             self._warn_about_suspicious_changes()
 
     def _warn_about_suspicious_changes(self):
@@ -282,7 +282,7 @@ def get_command(scaffolding, command_path):
 
 
 def create_run(experiment, command_name, config_updates=None,
-               named_configs=(), disable_suspicious_changes_warnings=False):
+               named_configs=(), force=False):
 
     sorted_ingredients = gather_ingredients_topological(experiment)
     scaffolding = create_scaffolding(experiment, sorted_ingredients)
@@ -327,7 +327,7 @@ def create_run(experiment, command_name, config_updates=None,
     if hasattr(main_function, 'unobserved'):
         run.unobserved = main_function.unobserved
 
-    run.disable_suspicious_changes_warnings = disable_suspicious_changes_warnings
+    run.force = force
 
     for scaffold in scaffolding.values():
         scaffold.finalize_initialization(run=run)

--- a/sacred/run.py
+++ b/sacred/run.py
@@ -81,6 +81,9 @@ class Run(object):
         self.unobserved = False
         """Indicates whether this run should be unobserved"""
 
+        self.disable_suspicious_changes_warnings = False
+        """Indicates whether warnings about suspicious changes should be disabled"""
+
         self._heartbeat = None
         self._failed_observers = []
 

--- a/sacred/run.py
+++ b/sacred/run.py
@@ -81,7 +81,7 @@ class Run(object):
         self.unobserved = False
         """Indicates whether this run should be unobserved"""
 
-        self.disable_suspicious_changes_warnings = False
+        self.force = False
         """Indicates whether warnings about suspicious changes should be disabled"""
 
         self._heartbeat = None

--- a/tests/test_arg_parser.py
+++ b/tests/test_arg_parser.py
@@ -20,6 +20,7 @@ from sacred.arg_parser import (_convert_value, get_config_updates, parse_args)
     ('--mongo_db=bar',   {'--mongo_db': 'bar'}),
     ('-l 10',            {'--loglevel': '10'}),
     ('--loglevel=30',    {'--loglevel': '30'}),
+    ('--disable_suspicious_changes_warnings', {'--disable_suspicious_changes_warnings': True}),
 ])
 def test_parse_individual_arguments(argv, expected):
     args = parse_args(['test_prog.py'] + argv.split(), print_help=False)

--- a/tests/test_arg_parser.py
+++ b/tests/test_arg_parser.py
@@ -20,7 +20,7 @@ from sacred.arg_parser import (_convert_value, get_config_updates, parse_args)
     ('--mongo_db=bar',   {'--mongo_db': 'bar'}),
     ('-l 10',            {'--loglevel': '10'}),
     ('--loglevel=30',    {'--loglevel': '30'}),
-    ('--disable_suspicious_changes_warnings', {'--disable_suspicious_changes_warnings': True}),
+    ('--force', {'--force': True}),
 ])
 def test_parse_individual_arguments(argv, expected):
     args = parse_args(['test_prog.py'] + argv.split(), print_help=False)


### PR DESCRIPTION
I often run quick experiments and change them by commenting/uncommenting stuff, often leaving me with "unused" parameters in the config file. The option --disable_suspicious_changes_warnings disables the warnings in that situation.