### PR TITLE
fix updates to the config that are provided through config_hooks

### DIFF
--- a/sacred/initialize.py
+++ b/sacred/initialize.py
@@ -294,23 +294,24 @@ def create_run(experiment, command_name, config_updates=None,
 
     past_paths = set()
     for scaffold in scaffolding.values():
-        scaffold.pick_relevant_config_updates(config_updates, past_paths)
-        past_paths.add(scaffold.path)
+        # get global config
         scaffold.gather_fallbacks()
         scaffold.set_up_config()
-
-        # update global config
         config = get_configuration(scaffolding)
         # run config hooks
         config_updates = scaffold.run_config_hooks(config, config_updates,
                                                    command_name, run_logger)
+        # update global config
+        scaffold.pick_relevant_config_updates(config_updates, past_paths)
+        scaffold.gather_fallbacks()
+        scaffold.set_up_config()
+        past_paths.add(scaffold.path)
 
     for scaffold in reversed(list(scaffolding.values())):
         scaffold.set_up_seed()  # partially recursive
 
     config = get_configuration(scaffolding)
     config_modifications = get_config_modifications(scaffolding)
-
     # ----------------------------------------------------
 
     experiment_info = experiment.get_experiment_info()


### PR DESCRIPTION
It seems that the config_hook mechanism is broken in sacred.
I am not 100% sure how they are intended to work as there was no "real use case" example in the tests but at least in the current version the hooks did not get applied at all.
Since the Bayesian optimization extension we are adding to sacred heavily relies on config_hooks I fixed them as in this commit.