### PR TITLE
change interface for config_hooks, they now get access to the args dict

### DIFF
--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -109,7 +109,7 @@ class Experiment(Ingredient):
                                 named_configs=named_configs)
 
     def run_command(self, command_name, config_updates=None,
-                    named_configs=(), args=()):
+                    named_configs=(), args={}):
         """Run the command with the given name.
 
         :param command_name: Name of the command to be run
@@ -126,7 +126,7 @@ class Experiment(Ingredient):
         :rtype: sacred.run.Run
         """
         run = self._create_run_for_command(command_name, config_updates,
-                                           named_configs)
+                                           named_configs, args)
         self.current_run = run
 
         for option in gather_command_line_options():

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -154,11 +154,11 @@ class Ingredient(object):
         ingredient.
         """
         argspec = inspect.getargspec(func)
-        args = ['config', 'command_name', 'logger']
+        args = ['config', 'command_name', 'logger', 'args']
         if not (argspec.args == args and argspec.varargs is None and
                 argspec.keywords is None and argspec.defaults is None):
             raise ValueError('Wrong signature for config_hook. Expected: '
-                             '(config, command_name, logger)')
+                             '(config, command_name, logger, args)')
         self.config_hooks.append(func)
         return self.config_hooks[-1]
 
@@ -304,7 +304,7 @@ class Ingredient(object):
     # ======================== Private Helpers ================================
 
     def _create_run_for_command(self, command_name, config_updates=None,
-                                named_configs=()):
+                                named_configs=(), args={}):
         run = create_run(self, command_name, config_updates,
-                         named_configs=named_configs)
+                         named_configs=named_configs, args=args)
         return run

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -118,7 +118,7 @@ def test_add_unobserved_command(ing):
 
 
 def test_add_config_hook(ing):
-    def foo(config, command_name, logger):
+    def foo(config, command_name, logger, args):
         pass
     ch = ing.config_hook(foo)
     assert ch == foo


### PR DESCRIPTION
This change was required to give easy access to the command arguments to the Bayesian optimization LabAssistant.
Beside, I would argue that it is a good idea to pass on the args to the config_hooks anyways :).
This commit also fixes a minor bug in sacred: the default parameter for args was an empty list while it should have been an empty dict.

BTW: Tell me if you would prefer these pull-requests to be made based on a different branch.