### PR TITLE
add_config_file does not exist

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -117,9 +117,9 @@ If you prefer, you can also directly load configuration entries from a file:
 
 .. code-block:: python
 
-    ex.add_config_file('conf.json')
-    ex.add_config_file('conf.pickle')  # if configuration was stored as dict
-    ex.add_config_file('conf.yaml')  # requires PyYAML
+    ex.add_config('conf.json')
+    ex.add_config('conf.pickle')  # if configuration was stored as dict
+    ex.add_config('conf.yaml')  # requires PyYAML
 
 This will essentially just read the file and add the resulting dictionary to
 the configuration with ``ex.add_config``.


### PR DESCRIPTION
It seems instances of Experiment don't have method `add_config_file()`, although stated in this doc. The `add_config()` methods implements to functionality in the example.