### PR TITLE
Added facility to apply a filter function to captured output.

### DIFF
--- a/examples/captured_out_filter.py
+++ b/examples/captured_out_filter.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# coding=utf-8
+"""
+This example shows how to apply a filter function to the captured output
+of a run. This is often useful when using progress bars or similar in the text
+UI and you don't want to store formatting characters like backspaces and
+linefeeds in the database.
+"""
+from __future__ import division, print_function, unicode_literals
+
+import sys
+import time
+
+from sacred import Experiment
+from sacred.utils import apply_backspaces_and_linefeeds
+
+ex = Experiment('progress')
+
+# try commenting out the line below to see the difference in captured output
+ex.captured_out_filter = apply_backspaces_and_linefeeds
+
+
+def write_and_flush(*args):
+    for arg in args:
+        sys.stdout.write(arg)
+    sys.stdout.flush()
+
+
+class ProgressMonitor(object):
+    def __init__(self, count):
+        self.count, self.progress = count, 0
+
+    def show(self, n=1):
+        self.progress += n
+        text = 'Completed {}/{} tasks'.format(self.progress, self.count)
+        write_and_flush('\b' * 80, '\r', text)
+
+    def done(self):
+        write_and_flush('\n')
+
+
+def progress(items):
+    p = ProgressMonitor(len(items))
+    for item in items:
+        yield item
+        p.show()
+    p.done()
+
+
+@ex.main
+def main():
+    for item in progress(range(100)):
+        time.sleep(0.05)
+
+
+if __name__ == '__main__':
+    run = ex.run_commandline()
+    print('=' * 80)
+    print('Captured output: ', repr(run.captured_out))

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -47,6 +47,8 @@ class Experiment(Ingredient):
         self.command(print_dependencies, unobserved=True)
         self.observers = []
         self.current_run = None
+        self.captured_out_filter = None
+        """Filter function to be applied to captured output of a run"""
 
     # =========================== Decorators ==================================
 

--- a/sacred/initialize.py
+++ b/sacred/initialize.py
@@ -322,7 +322,7 @@ def create_run(experiment, command_name, config_updates=None,
 
     run = Run(config, config_modifications, main_function,
               experiment.observers, root_logger, run_logger, experiment_info,
-              host_info, pre_runs, post_runs)
+              host_info, pre_runs, post_runs, experiment.captured_out_filter)
 
     if hasattr(main_function, 'unobserved'):
         run.unobserved = main_function.unobserved

--- a/sacred/utils.py
+++ b/sacred/utils.py
@@ -281,3 +281,29 @@ def convert_camel_case_to_snake_case(name):
     """Convert CamelCase to snake_case."""
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+
+
+def apply_backspaces_and_linefeeds(text):
+    """
+    Interpret backspaces and linefeeds in text like a terminal would.
+
+    Interpret text like a terminal by removing backspace and linefeed
+    characters and applying them line by line.
+    """
+    lines = []
+    for line in text.split('\n'):
+        chars, cursor = [], 0
+        for ch in line:
+            if ch == '\b':
+                cursor = max(0, cursor - 1)
+            elif ch == '\r':
+                cursor = 0
+            else:
+                # normal character
+                if cursor == len(chars):
+                    chars.append(ch)
+                else:
+                    chars[cursor] = ch
+                cursor += 1
+        lines.append(''.join(chars))
+    return '\n'.join(lines)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -161,3 +161,19 @@ def test_using_a_named_config(ex):
 
     assert ex.run().result == 1
     assert ex.run(named_configs=['ncfg']).result == 10
+
+
+def test_captured_out_filter(ex):
+    from sacred.utils import apply_backspaces_and_linefeeds
+    ex.captured_out_filter = apply_backspaces_and_linefeeds
+
+    @ex.main
+    def run_print_mock_progress():
+        sys.stdout.write('progress 0')
+        sys.stdout.flush()
+        for i in range(10):
+            sys.stdout.write('\b')
+            sys.stdout.write(str(i))
+            sys.stdout.flush()
+
+    assert ex.run().captured_out == 'progress 9'

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -6,6 +6,7 @@ import mock
 import os
 import pytest
 import tempfile
+import sys
 
 from sacred.run import Run
 from sacred.config.config_summary import ConfigSummary
@@ -209,3 +210,18 @@ def test_unobserved_run_doesnt_emit(run):
     assert not observer.completed_event.called
     assert not observer.interrupted_event.called
     assert not observer.failed_event.called
+
+
+def test_captured_out_filter(run):
+    from sacred.utils import apply_backspaces_and_linefeeds
+    def print_mock_progress():
+        sys.stdout.write('progress 0')
+        sys.stdout.flush()
+        for i in range(10):
+            sys.stdout.write('\b')
+            sys.stdout.write(str(i))
+            sys.stdout.flush()
+    run.captured_out_filter = apply_backspaces_and_linefeeds
+    run.main_function.side_effect = print_mock_progress
+    run()
+    assert run.captured_out == 'progress 9'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,8 @@ from sacred.utils import (PATHCHANGE, convert_to_nested_dict,
                           iter_path_splits, iter_prefixes, iterate_flattened,
                           iterate_flattened_separately, join_paths,
                           recursive_update, set_by_dotted_path, get_inheritors,
-                          convert_camel_case_to_snake_case)
+                          convert_camel_case_to_snake_case,
+                          apply_backspaces_and_linefeeds)
 
 
 def test_recursive_update():
@@ -147,3 +148,20 @@ def test_get_inheritors():
 ])
 def test_convert_camel_case_to_snake_case(name, expected):
     assert convert_camel_case_to_snake_case(name) == expected
+
+
+@pytest.mark.parametrize('text,expected', [
+    ('', ''),
+    ('\b', ''),
+    ('\r', ''),
+    ('ab\bc', 'ac'),
+    ('\ba', 'a'),
+    ('ab\nc\b\bd', 'ab\nd'),
+    ('abc\rdef', 'def'),
+    ('abc\r', 'abc'),
+    ('abc\rd', 'dbc'),
+    ('abc\ndef\rg', 'abc\ngef'),
+    ('abc\ndef\r\rg', 'abc\ngef')
+])
+def test_apply_backspaces_and_linefeeds(text, expected):
+    assert apply_backspaces_and_linefeeds(text) == expected


### PR DESCRIPTION
Adds a facility to apply a filter function to captured output. This is useful in situations where your experiment code uses a console based progress bar or similar in the text UI, but you would rather not have the observer store the control characters like backspaces and linefeeds in the database. This can be achieved by setting the `captured_out_filter` on the run or experiment as follows:

```
from sacred.utils import apply_backspaces_and_linefeeds

ex = Experiment('progress')
ex.captured_out_filter = apply_backspaces_and_linefeeds
```

It would be possible to also implement this kind of thing by subclassing the observers and filtering the text there, or by changing the observers directly. However, in this case, the user would need to configure all observers. It would also make it harder to implement adding the observer via the command line interface like you can do now.