### PR TITLE
initialize typechange for None should be ignored

### DIFF
--- a/sacred/initialize.py
+++ b/sacred/initialize.py
@@ -171,7 +171,7 @@ class Scaffold(object):
                 self.logger.warning('Added new config entry: "%s"' % add)
 
         for key, (type_old, type_new) in self.config_mods.typechanged.items():
-            if (isinstance(type_old, type(None)) or
+            if type_old is type(None) or
                     (type_old in (int, float) and type_new in (int, float))):
                 continue
             self.logger.warning(

--- a/sacred/initialize.py
+++ b/sacred/initialize.py
@@ -171,7 +171,7 @@ class Scaffold(object):
                 self.logger.warning('Added new config entry: "%s"' % add)
 
         for key, (type_old, type_new) in self.config_mods.typechanged.items():
-            if type_old is type(None) or
+            if (type_old is type(None) or
                     (type_old in (int, float) and type_new in (int, float))):
                 continue
             self.logger.warning(


### PR DESCRIPTION
The if statement in the code says, that typechanged for None should be ignored,  but it does not ignore it.
 
isinstance(type_old, type(None)) is always false
type_old is type(None) checks if the type is NoneType