### PR TITLE
Add TinyDbObserver for local file system alternative.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,6 @@ mongomock
 pymongo
 pyyaml
 pytest-cov
+tinydb
+tinydb-serialization
+hashfs

--- a/sacred/commands.py
+++ b/sacred/commands.py
@@ -38,6 +38,7 @@ def _non_unicode_repr(objekt, context, maxlevels, level):
         repr_string = repr_string[1:]
     return repr_string, isreadable, isrecursive
 
+
 PRINTER = pprint.PrettyPrinter()
 PRINTER.format = _non_unicode_repr
 

--- a/sacred/config/config_files.py
+++ b/sacred/config/config_files.py
@@ -17,6 +17,7 @@ class Handler(object):
         self.dump = dump
         self.mode = mode
 
+
 HANDLER_BY_EXT = {
     '.json': Handler(lambda fp: json.decode(fp.read()),
                      lambda obj, fp: fp.write(json.encode(obj)), ''),

--- a/sacred/observers/__init__.py
+++ b/sacred/observers/__init__.py
@@ -7,6 +7,7 @@ from sacred.commandline_options import CommandLineOption
 from sacred.observers.base import RunObserver
 from sacred.observers.file_storage import FileStorageObserver
 import sacred.optional as opt
+from sacred.observers.tinydb_hashfs import TinyDbObserver
 
 if opt.has_pymongo:
     from sacred.observers.mongo import MongoObserver
@@ -40,4 +41,4 @@ else:
 
 
 __all__ = ('FileStorageObserver', 'RunObserver', 'MongoObserver',
-           'SqlObserver')
+           'SqlObserver', 'TinyDbObserver')

--- a/sacred/observers/__init__.py
+++ b/sacred/observers/__init__.py
@@ -7,7 +7,7 @@ from sacred.commandline_options import CommandLineOption
 from sacred.observers.base import RunObserver
 from sacred.observers.file_storage import FileStorageObserver
 import sacred.optional as opt
-from sacred.observers.tinydb_hashfs import TinyDbObserver
+from sacred.observers.tinydb_hashfs import TinyDbObserver, TinyDbReader
 
 if opt.has_pymongo:
     from sacred.observers.mongo import MongoObserver
@@ -41,4 +41,4 @@ else:
 
 
 __all__ = ('FileStorageObserver', 'RunObserver', 'MongoObserver',
-           'SqlObserver', 'TinyDbObserver')
+           'SqlObserver', 'TinyDbObserver', 'TinyDbReader')

--- a/sacred/observers/sql.py
+++ b/sacred/observers/sql.py
@@ -189,6 +189,7 @@ class Experiment(Base):
                 'sources': [s.to_json() for s in self.sources],
                 'dependencies': [d.to_json() for d in self.dependencies]}
 
+
 run_resource_association = sa.Table(
     'runs_resources', Base.metadata,
     sa.Column('run_id', sa.String(24), sa.ForeignKey('run.run_id')),

--- a/sacred/observers/tinydb.py
+++ b/sacred/observers/tinydb.py
@@ -29,7 +29,7 @@ class DateTimeSerializer(Serializer):
 
 
 class NdArraySerializer(Serializer):
-    OBJ_CLASS = opt.np.ndarray  # The class this serializer handles
+    OBJ_CLASS = opt.np.ndarray 
 
     def encode(self, obj):
         return json.dumps(obj.tolist(), check_circular=True)
@@ -39,13 +39,23 @@ class NdArraySerializer(Serializer):
 
 
 class DataFrameSerializer(Serializer):
-    OBJ_CLASS = opt.pandas.DataFrame  # The class this serializer handles
+    OBJ_CLASS = opt.pandas.DataFrame 
 
     def encode(self, obj):
         return obj.to_json()
 
     def decode(self, s):
         return opt.pandas.read_json(s)
+
+
+class SeriesSerializer(Serializer):
+    OBJ_CLASS = opt.pandas.core.series.Series  
+
+    def encode(self, obj):
+        return obj.to_json()
+
+    def decode(self, s):
+        return opt.pandas.read_json(s, typ='series')
 
 
 class TinyDbObserver(RunObserver):
@@ -65,6 +75,7 @@ class TinyDbObserver(RunObserver):
         serialization_store.register_serializer(DateTimeSerializer(), 'TinyDate')
         serialization_store.register_serializer(NdArraySerializer(), 'TinyArray')
         serialization_store.register_serializer(DataFrameSerializer(), 'TinyDataFrame')
+        serialization_store.register_serializer(SeriesSerializer(), 'TinySeries')
 
         db = TinyDB(os.path.join(root_dir, 'metadata.json'), storage=serialization_store)
         fs = HashFS(os.path.join(root_dir, 'hashfs'), depth=3, width=2, algorithm='md5')

--- a/sacred/observers/tinydb.py
+++ b/sacred/observers/tinydb.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+# coding=utf-8
+import os
+import datetime as dt 
+import uuid
+
+from sacred.__about__ import __version__
+from sacred.observers import RunObserver
+from sacred.dependencies import get_digest
+import sacred.optional as opt
+
+from tinydb import TinyDB
+from tinydb.middlewares import Middleware
+from tinydb.storages import JSONStorage
+
+from hashfs import HashFS
+
+
+class TinyDbObserver(RunObserver):
+
+    VERSION = "TinyDbObserver-{}".format(__version__)
+
+    @staticmethod 
+    def create(path='.', name='observer_db', overwrite=None):
+
+        location = os.path.abspath(path)
+        root_dir = os.path.join(location, name)
+        if not os.path.exists(root_dir):
+            os.makedirs(root_dir)
+
+        db = TinyDB(os.path.join(root_dir, 'metadata.json'),
+                    storage=SerializeArrayDataFrameMiddleware(JSONStorage))
+        fs = HashFS(os.path.join(root_dir, 'hashfs'), depth=3, width=2, algorithm='md5')
+
+        return TinyDbObserver(db, fs, overwrite=overwrite)
+
+    def __init__(self, db, fs, overwrite=None):
+        self.db = db
+        self.runs = db.table('runs')
+        self.fs = fs
+        self.overwrite = overwrite
+        self.run_entry = {}
+        self.db_run_id = None
+
+    def save(self):
+        """ Insert or update the current entry """
+        if self.db_run_id:
+            self.runs.update(self.run_entry, eids=[self.db_run_id])
+        else:
+            db_run_id = self.runs.insert(self.run_entry)
+            self.db_run_id = db_run_id
+
+    def save_sources(self, ex_info):
+        
+        # base_dir = ex_info['base_dir']
+        source_info = []
+        for source_name, md5 in ex_info['sources']:
+        
+            file = self.fs.get(md5)
+            if file:
+                id_ = file.id
+            else:
+                # Substitute any HOME or Environment Vars to get absolute path
+                abs_path = os.path.expanduser(source_name)
+                abs_path = os.path.expandvars(source_name)
+                with open(abs_path, 'rb') as f:
+                    address = self.fs.put(f)
+                    id_ = address.id
+            source_info.append([source_name, id_])
+        return source_info
+
+    def queued_event(self, ex_info, command, queue_time, config, meta_info,
+                     _id):
+        raise NotImplementedError('queued_event method is not implimented for local TinyDbObserver.')
+
+    def started_event(self, ex_info, command, host_info, start_time, config,
+                      meta_info, _id):
+
+        self.run_entry = {
+            'experiment': dict(ex_info),
+            'format': self.VERSION,
+            'command': command,
+            'host': dict(host_info),
+            'start_time': start_time,
+            'config': config,
+            'meta': meta_info,
+            'status': 'RUNNING',
+            'resources': [],
+            'artifacts': [],
+            'captured_out': '',
+            'info': {},
+            'heartbeat': None
+        }
+
+        # set ID if not given
+        if _id is None:
+            _id = uuid.uuid4().hex
+
+        self.run_entry['_id'] = _id
+        
+        # save sources
+        self.run_entry['experiment']['sources'] = self.save_sources(ex_info)
+        self.save()
+        return self.run_entry['_id']
+
+    def heartbeat_event(self, info, cout_filename, beat_time):
+        self.run_entry['info'] = info
+        with open(cout_filename, 'r') as f:
+            self.run_entry['captured_out'] = f.read()
+        self.run_entry['heartbeat'] = beat_time
+        self.save()
+
+    def completed_event(self, stop_time, result):
+        self.run_entry['stop_time'] = stop_time
+        self.run_entry['result'] = result
+        self.run_entry['status'] = 'COMPLETED'
+        self.save()
+
+    def interrupted_event(self, interrupt_time, status):
+        self.run_entry['stop_time'] = interrupt_time
+        self.run_entry['status'] = status
+        self.save()
+
+    def failed_event(self, fail_time, fail_trace):
+        self.run_entry['stop_time'] = fail_time
+        self.run_entry['status'] = 'FAILED'
+        self.run_entry['fail_trace'] = fail_trace
+        self.save()
+
+    def resource_event(self, filename):
+
+        md5hash = get_digest(filename)
+        file_ = self.fs.get(md5hash)
+
+        if file_:
+            resource = (filename, md5hash)
+            if resource not in self.run_entry['resources']:
+                self.run_entry['resources'].append(resource)
+                self.save()
+        else: 
+            self.fs.put(filename)
+            self.run_entry['resources'].append((filename, md5hash))
+            self.save()
+
+    def artifact_event(self, filename):
+
+        md5hash = get_digest(filename)
+        file_ = self.fs.get(md5hash)
+
+        if file_:
+            artifact = (filename, md5hash)
+            if artifact not in self.run_entry['artifacts']:
+                self.run_entry['artifacts'].append(artifact)
+                self.save()
+        else: 
+            self.fs.put(filename)
+            self.run_entry['artifacts'].append((filename, md5hash))
+            self.save()
+
+    def __eq__(self, other):
+        if isinstance(other, TinyDbObserver):
+            return self.runs == other.runs
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class SerializeArrayDataFrameMiddleware(Middleware):
+
+    """ Custom Middleware to handle arrays and DataFrame serialisation """
+    
+    def __init__(self, storage_cls=TinyDB.DEFAULT_STORAGE):
+        # Any middleware *has* to call the super constructor
+        # with storage_cls
+        super(SerializeArrayDataFrameMiddleware, self).__init__(storage_cls)
+
+    def read(self):
+        data = self.storage.read()
+
+        return data
+
+    def write(self, data):
+
+        for table_name in data:
+            table = data[table_name]
+
+            for element_id in table:
+                doc = table[element_id]
+                doc = self._convert(doc)
+
+        self.storage.write(data)
+
+    def _convert(self, doc):
+        """ Recursively convert array and DataFrame to lists/json """
+        for key, value in doc.items():
+            if isinstance(value, (opt.pandas.Series, opt.pandas.DataFrame, opt.pandas.Panel)):
+                doc[key] = value.to_json()
+            elif isinstance(value, opt.np.ndarray):
+                doc[key] = value.tolist()
+            elif isinstance(value, dt.datetime):
+                doc[key] = value.isoformat()
+            elif isinstance(value, dict):
+                # Make sure we recurse into sub-docs
+                doc[key] = self._convert(value)
+        return doc
+
+    def close(self):
+        self.storage.close()

--- a/sacred/observers/tinydb.py
+++ b/sacred/observers/tinydb.py
@@ -27,7 +27,10 @@ class DateTimeSerializer(Serializer):
 
 
 class NdArraySerializer(Serializer):
-    OBJ_CLASS = opt.np.ndarray 
+
+    def __init__(self, *args, **kwds):
+        super(NdArraySerializer).__init__(self, *args, **kwds)
+        self.OBJ_CLASS = opt.np.ndarray
 
     def encode(self, obj):
         return json.dumps(obj.tolist(), check_circular=True)
@@ -37,7 +40,10 @@ class NdArraySerializer(Serializer):
 
 
 class DataFrameSerializer(Serializer):
-    OBJ_CLASS = opt.pandas.DataFrame 
+
+    def __init__(self, *args, **kwds):
+        super(DataFrameSerializer).__init__(self, *args, **kwds)
+        self.OBJ_CLASS = opt.pandas.DataFrame 
 
     def encode(self, obj):
         return obj.to_json()
@@ -47,7 +53,10 @@ class DataFrameSerializer(Serializer):
 
 
 class SeriesSerializer(Serializer):
-    OBJ_CLASS = opt.pandas.core.series.Series  
+
+    def __init__(self, *args, **kwds):
+        super(SeriesSerializer).__init__(self, *args, **kwds)
+        self.OBJ_CLASS = opt.pandas.Series 
 
     def encode(self, obj):
         return obj.to_json()
@@ -71,9 +80,11 @@ class TinyDbObserver(RunObserver):
         # Setup Serialisation object for non list/dict objects 
         serialization_store = SerializationMiddleware()
         serialization_store.register_serializer(DateTimeSerializer(), 'TinyDate')
-        serialization_store.register_serializer(NdArraySerializer(), 'TinyArray')
-        serialization_store.register_serializer(DataFrameSerializer(), 'TinyDataFrame')
-        serialization_store.register_serializer(SeriesSerializer(), 'TinySeries')
+        if opt.has_numpy:
+            serialization_store.register_serializer(NdArraySerializer(), 'TinyArray')
+        if opt.has_pandas:    
+            serialization_store.register_serializer(DataFrameSerializer(), 'TinyDataFrame')
+            serialization_store.register_serializer(SeriesSerializer(), 'TinySeries')
 
         db = TinyDB(os.path.join(root_dir, 'metadata.json'), storage=serialization_store)
         fs = HashFS(os.path.join(root_dir, 'hashfs'), depth=3, width=2, algorithm='md5')

--- a/sacred/observers/tinydb.py
+++ b/sacred/observers/tinydb.py
@@ -100,7 +100,6 @@ class TinyDbObserver(RunObserver):
 
     def save_sources(self, ex_info):
         
-        # base_dir = ex_info['base_dir']
         source_info = []
         for source_name, md5 in ex_info['sources']:
         
@@ -111,9 +110,8 @@ class TinyDbObserver(RunObserver):
                 # Substitute any HOME or Environment Vars to get absolute path
                 abs_path = os.path.expanduser(source_name)
                 abs_path = os.path.expandvars(source_name)
-                with open(abs_path, 'rb') as f:
-                    address = self.fs.put(f)
-                    id_ = address.id
+                address = self.fs.put(abs_path)
+                id_ = address.id
             source_info.append([source_name, id_])
         return source_info
 

--- a/sacred/observers/tinydb.py
+++ b/sacred/observers/tinydb.py
@@ -11,8 +11,6 @@ from sacred.dependencies import get_digest
 import sacred.optional as opt
 
 from tinydb import TinyDB
-from tinydb.middlewares import Middleware
-from tinydb.storages import JSONStorage
 from tinydb_serialization import Serializer, SerializationMiddleware
 
 from hashfs import HashFS
@@ -204,46 +202,3 @@ class TinyDbObserver(RunObserver):
 
     def __ne__(self, other):
         return not self.__eq__(other)
-
-
-# class SerializeArrayDataFrameMiddleware(Middleware):
-
-#     """ Custom Middleware to handle arrays and DataFrame serialisation """
-    
-#     def __init__(self, storage_cls=TinyDB.DEFAULT_STORAGE):
-#         # Any middleware *has* to call the super constructor
-#         # with storage_cls
-#         super(SerializeArrayDataFrameMiddleware, self).__init__(storage_cls)
-
-#     def read(self):
-#         data = self.storage.read()
-
-#         return data
-
-#     def write(self, data):
-
-#         for table_name in data:
-#             table = data[table_name]
-
-#             for element_id in table:
-#                 doc = table[element_id]
-#                 doc = self._convert(doc)
-
-#         self.storage.write(data)
-
-#     def _convert(self, doc):
-#         """ Recursively convert array and DataFrame to lists/json """
-#         for key, value in doc.items():
-#             if isinstance(value, (opt.pandas.Series, opt.pandas.DataFrame, opt.pandas.Panel)):
-#                 doc[key] = value.to_json()
-#             elif isinstance(value, opt.np.ndarray):
-#                 doc[key] = value.tolist()
-#             elif isinstance(value, dt.datetime):
-#                 doc[key] = value.isoformat()
-#             elif isinstance(value, dict):
-#                 # Make sure we recurse into sub-docs
-#                 doc[key] = self._convert(value)
-#         return doc
-
-#     def close(self):
-#         self.storage.close()

--- a/sacred/observers/tinydb.py
+++ b/sacred/observers/tinydb.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
 import os
-import datetime as dt 
+import datetime as dt
 import json
 import uuid
 
@@ -43,7 +43,7 @@ class DataFrameSerializer(Serializer):
 
     def __init__(self, *args, **kwds):
         super(DataFrameSerializer).__init__(self, *args, **kwds)
-        self.OBJ_CLASS = opt.pandas.DataFrame 
+        self.OBJ_CLASS = opt.pandas.DataFrame
 
     def encode(self, obj):
         return obj.to_json()
@@ -56,7 +56,7 @@ class SeriesSerializer(Serializer):
 
     def __init__(self, *args, **kwds):
         super(SeriesSerializer).__init__(self, *args, **kwds)
-        self.OBJ_CLASS = opt.pandas.Series 
+        self.OBJ_CLASS = opt.pandas.Series
 
     def encode(self, obj):
         return obj.to_json()
@@ -69,7 +69,7 @@ class TinyDbObserver(RunObserver):
 
     VERSION = "TinyDbObserver-{}".format(__version__)
 
-    @staticmethod 
+    @staticmethod
     def create(path='.', name='observer_db', overwrite=None):
 
         location = os.path.abspath(path)
@@ -77,17 +77,23 @@ class TinyDbObserver(RunObserver):
         if not os.path.exists(root_dir):
             os.makedirs(root_dir)
 
-        # Setup Serialisation object for non list/dict objects 
+        # Setup Serialisation object for non list/dict objects
         serialization_store = SerializationMiddleware()
-        serialization_store.register_serializer(DateTimeSerializer(), 'TinyDate')
+        serialization_store.register_serializer(DateTimeSerializer(),
+                                                'TinyDate')
         if opt.has_numpy:
-            serialization_store.register_serializer(NdArraySerializer(), 'TinyArray')
-        if opt.has_pandas:    
-            serialization_store.register_serializer(DataFrameSerializer(), 'TinyDataFrame')
-            serialization_store.register_serializer(SeriesSerializer(), 'TinySeries')
+            serialization_store.register_serializer(NdArraySerializer(),
+                                                    'TinyArray')
+        if opt.has_pandas:
+            serialization_store.register_serializer(DataFrameSerializer(),
+                                                    'TinyDataFrame')
+            serialization_store.register_serializer(SeriesSerializer(),
+                                                    'TinySeries')
 
-        db = TinyDB(os.path.join(root_dir, 'metadata.json'), storage=serialization_store)
-        fs = HashFS(os.path.join(root_dir, 'hashfs'), depth=3, width=2, algorithm='md5')
+        db = TinyDB(os.path.join(root_dir, 'metadata.json'),
+                    storage=serialization_store)
+        fs = HashFS(os.path.join(root_dir, 'hashfs'), depth=3,
+                    width=2, algorithm='md5')
 
         return TinyDbObserver(db, fs, overwrite=overwrite)
 
@@ -108,10 +114,10 @@ class TinyDbObserver(RunObserver):
             self.db_run_id = db_run_id
 
     def save_sources(self, ex_info):
-        
+
         source_info = []
         for source_name, md5 in ex_info['sources']:
-        
+
             file = self.fs.get(md5)
             if file:
                 id_ = file.id
@@ -126,7 +132,8 @@ class TinyDbObserver(RunObserver):
 
     def queued_event(self, ex_info, command, queue_time, config, meta_info,
                      _id):
-        raise NotImplementedError('queued_event method is not implimented for local TinyDbObserver.')
+        raise NotImplementedError('queued_event method is not implimented for'
+                                  ' local TinyDbObserver.')
 
     def started_event(self, ex_info, command, host_info, start_time, config,
                       meta_info, _id):
@@ -152,7 +159,7 @@ class TinyDbObserver(RunObserver):
             _id = uuid.uuid4().hex
 
         self.run_entry['_id'] = _id
-        
+
         # save sources
         self.run_entry['experiment']['sources'] = self.save_sources(ex_info)
         self.save()
@@ -187,12 +194,12 @@ class TinyDbObserver(RunObserver):
         md5hash = get_digest(filename)
         file_ = self.fs.get(md5hash)
         resource = (filename, md5hash)
-        
+
         if file_:
             if resource not in self.run_entry['resources']:
                 self.run_entry['resources'].append(resource)
                 self.save()
-        else: 
+        else:
             self.fs.put(filename)
             self.run_entry['resources'].append((filename, md5hash))
             self.save()

--- a/sacred/observers/tinydb.py
+++ b/sacred/observers/tinydb.py
@@ -106,7 +106,7 @@ class TinyDbObserver(RunObserver):
         self.db_run_id = None
 
     def save(self):
-        """ Insert or update the current entry """
+        """Insert or update the current run entry."""
         if self.db_run_id:
             self.runs.update(self.run_entry, eids=[self.db_run_id])
         else:

--- a/sacred/observers/tinydb.py
+++ b/sacred/observers/tinydb.py
@@ -15,6 +15,8 @@ from tinydb_serialization import Serializer, SerializationMiddleware
 
 from hashfs import HashFS
 
+__sacred__ = True  # marks files that should be filtered from stack traces
+
 
 class DateTimeSerializer(Serializer):
     OBJ_CLASS = dt.datetime  # The class this serializer handles

--- a/sacred/observers/tinydb_hashfs.py
+++ b/sacred/observers/tinydb_hashfs.py
@@ -34,13 +34,13 @@ class BufferedReaderWrapper(BufferedReader):
 
     """Custom wrapper to allow for copying of file handle.
 
-    tinydb_serialisation currently does a deepcopy on all the content of the 
-    dictionary before serialisation. By default, file handles are not 
-    copiable so this wrapper is necessary to create a duplicate of the 
-    file handle passes in.  
+    tinydb_serialisation currently does a deepcopy on all the content of the
+    dictionary before serialisation. By default, file handles are not
+    copiable so this wrapper is necessary to create a duplicate of the
+    file handle passes in.
 
     Note that the file passed in will therefor remain open as the copy is the
-    one thats closed.
+    one that gets closed.
     """
 
     def __init__(self, *args, **kwargs):
@@ -246,7 +246,7 @@ class TinyDbObserver(RunObserver):
     def resource_event(self, filename):
 
         id_ = self.fs.put(filename).id
-        handle = BufferedReaderWrapper(open(filename, 'rb'))        
+        handle = BufferedReaderWrapper(open(filename, 'rb'))
         resource = [filename, id_, handle]
 
         if resource not in self.run_entry['resources']:
@@ -256,9 +256,9 @@ class TinyDbObserver(RunObserver):
     def artifact_event(self, name, filename):
 
         id_ = self.fs.put(filename).id
-        handle = BufferedReaderWrapper(open(filename, 'rb'))        
+        handle = BufferedReaderWrapper(open(filename, 'rb'))
         artifact = [name, filename, id_, handle]
-        
+
         if artifact not in self.run_entry['artifacts']:
             self.run_entry['artifacts'].append(artifact)
             self.save()
@@ -329,12 +329,12 @@ class TinyDbReader(object):
         """Return Dictionary of files for experiment name or query.
 
         Returns a list of one dictionary per matched experiment. The
-        dictionary is of the following structure 
+        dictionary is of the following structure
 
             {
               'exp_name': 'scascasc',
               'exp_id': 'dqwdqdqwf',
-              'date': datatime_object, 
+              'date': datatime_object,
               'sources': [ {'filename': filehandle}, ..., ],
               'resources': [ {'filename': filehandle}, ..., ],
               'artifacts': [ {'filename': filehandle}, ..., ]
@@ -348,7 +348,7 @@ class TinyDbReader(object):
         for ent in entries:
 
             rec = dict(exp_name=ent['experiment']['name'],
-                       exp_id=ent['_id'], 
+                       exp_id=ent['_id'],
                        date=ent['start_time'])
 
             source_files = {x[0]: x[2] for x in ent['experiment']['sources']}
@@ -394,7 +394,7 @@ Outputs:
 {artifacts}
 """
 
-        entries = self.fetch_metadata(exp_name, query, indices) 
+        entries = self.fetch_metadata(exp_name, query, indices)
 
         all_matched_entries = []
         for ent in entries:
@@ -428,13 +428,13 @@ Outputs:
 
             none_str = '    None'
 
-            rec = dict(exp_name=ent['experiment']['name'], 
-                       exp_id=ent['_id'], 
-                       start_date=date, 
+            rec = dict(exp_name=ent['experiment']['name'],
+                       exp_id=ent['_id'],
+                       start_date=date,
                        duration=duration,
                        parameters=parameters if parameters else none_str,
-                       result=result if result else none_str, 
-                       dependencies=deps if deps else none_str, 
+                       result=result if result else none_str,
+                       dependencies=deps if deps else none_str,
                        resources=resources if resources else none_str,
                        sources=sources if sources else none_str,
                        artifacts=artifacts if artifacts else none_str)
@@ -454,9 +454,9 @@ Outputs:
                 q = query
             elif exp_name:
                 q = Query().experiment.name.search(exp_name)
-    
+
             entries = self.runs.search(q)
-    
+
         elif indices or indices == 0:
             if not isinstance(indices, (tuple, list)):
                 indices = [indices]
@@ -465,8 +465,9 @@ Outputs:
 
             for idx in indices:
                 if idx >= num_recs:
-                    raise ValueError('Index value ({}) must be less than '
-                            'number of records ({})'.format(idx, num_recs))
+                    raise ValueError(
+                        'Index value ({}) must be less than '
+                        'number of records ({})'.format(idx, num_recs))
 
             entries = [self.runs.all()[ind] for ind in indices]
 
@@ -479,7 +480,7 @@ Outputs:
     def _dict_to_indented_list(self, d):
 
         d = OrderedDict(sorted(d.items(), key=lambda t: t[0]))
-        
+
         output_str = ''
 
         for k, v in d.items():

--- a/sacred/observers/tinydb_hashfs.py
+++ b/sacred/observers/tinydb_hashfs.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
+from __future__ import division, print_function, unicode_literals
+
 import os
 import datetime as dt
 import json
@@ -11,9 +13,8 @@ from sacred.dependencies import get_digest
 import sacred.optional as opt
 
 from tinydb import TinyDB
+from hashFS import HashFS
 from tinydb_serialization import Serializer, SerializationMiddleware
-
-from hashfs import HashFS
 
 __sacred__ = True  # marks files that should be filtered from stack traces
 

--- a/sacred/observers/tinydb_hashfs.py
+++ b/sacred/observers/tinydb_hashfs.py
@@ -19,7 +19,7 @@ from tinydb_serialization import Serializer, SerializationMiddleware
 
 __sacred__ = True  # marks files that should be filtered from stack traces
 
-# Set data type values for abstract properties in Serializers 
+# Set data type values for abstract properties in Serializers
 series_type = opt.pandas.Series if opt.has_pandas else None
 dataframe_type = opt.pandas.DataFrame if opt.has_pandas else None
 ndarray_type = opt.np.ndarray if opt.has_numpy else None

--- a/sacred/observers/tinydb_hashfs.py
+++ b/sacred/observers/tinydb_hashfs.py
@@ -71,10 +71,9 @@ class TinyDbObserver(RunObserver):
     VERSION = "TinyDbObserver-{}".format(__version__)
 
     @staticmethod
-    def create(path='.', name='observer_db', overwrite=None):
+    def create(path='./runs_db', overwrite=None):
 
-        location = os.path.abspath(path)
-        root_dir = os.path.join(location, name)
+        root_dir = os.path.abspath(path)
         if not os.path.exists(root_dir):
             os.makedirs(root_dir)
 
@@ -226,25 +225,14 @@ class TinyDbObserver(RunObserver):
 class TinyDbOption(CommandLineOption):
     """Add a TinyDB Observer to the experiment."""
 
-    arg = 'LOCATION'
-    arg_description = ("Root location and name for Tinydb-hash file system. "
-                       "Can be [path/to/location/]db_name defaulting to "
-                       "current directory with db named 'observer_db'")
+    arg = 'BASEDIR'
 
     @classmethod
     def apply(cls, args, run):
-        location, db_name = cls.parse_tinydb_arg(args)
-        tinydb_obs = TinyDbObserver.create(path=location, name=db_name)
+        location = cls.parse_tinydb_arg(args)
+        tinydb_obs = TinyDbObserver.create(path=location)
         run.observers.append(tinydb_obs)
 
     @classmethod
     def parse_tinydb_arg(cls, args):
-
-        head, tail = os.path.split(args)
-
-        if not head:
-            head = '.'
-        if not tail:
-            tail = 'observer_db'
-
-        return head, tail
+        return args

--- a/sacred/observers/tinydb_hashfs.py
+++ b/sacred/observers/tinydb_hashfs.py
@@ -19,6 +19,11 @@ from tinydb_serialization import Serializer, SerializationMiddleware
 
 __sacred__ = True  # marks files that should be filtered from stack traces
 
+# Set data type values for abstract properties in Serializers 
+series_type = opt.pandas.Series if opt.has_pandas else None
+dataframe_type = opt.pandas.DataFrame if opt.has_pandas else None
+ndarray_type = opt.np.ndarray if opt.has_numpy else None
+
 
 class DateTimeSerializer(Serializer):
     OBJ_CLASS = dt.datetime  # The class this serializer handles
@@ -31,10 +36,7 @@ class DateTimeSerializer(Serializer):
 
 
 class NdArraySerializer(Serializer):
-
-    def __init__(self, *args, **kwds):
-        super(NdArraySerializer).__init__(self, *args, **kwds)
-        self.OBJ_CLASS = opt.np.ndarray
+    OBJ_CLASS = ndarray_type
 
     def encode(self, obj):
         return json.dumps(obj.tolist(), check_circular=True)
@@ -44,10 +46,7 @@ class NdArraySerializer(Serializer):
 
 
 class DataFrameSerializer(Serializer):
-
-    def __init__(self, *args, **kwds):
-        super(DataFrameSerializer).__init__(self, *args, **kwds)
-        self.OBJ_CLASS = opt.pandas.DataFrame
+    OBJ_CLASS = dataframe_type
 
     def encode(self, obj):
         return obj.to_json()
@@ -57,10 +56,7 @@ class DataFrameSerializer(Serializer):
 
 
 class SeriesSerializer(Serializer):
-
-    def __init__(self, *args, **kwds):
-        super(SeriesSerializer).__init__(self, *args, **kwds)
-        self.OBJ_CLASS = opt.pandas.Series
+    OBJ_CLASS = series_type
 
     def encode(self, obj):
         return obj.to_json()

--- a/sacred/observers/tinydb_hashfs.py
+++ b/sacred/observers/tinydb_hashfs.py
@@ -326,9 +326,9 @@ class TinyDbReader(object):
         return self.runs.search(*args, **kwargs)
 
     def fetch_files(self, exp_name=None, query=None, indices=None):
-        """Return Dictionary of files for experiment name or query. 
+        """Return Dictionary of files for experiment name or query.
 
-        Returns a list of one dictionary per matched experiment. The 
+        Returns a list of one dictionary per matched experiment. The
         dictionary is of the following structure 
 
             {
@@ -378,7 +378,7 @@ Date: {start_date}    Duration: {duration}
 Parameters:
 {parameters}
 
-Result: 
+Result:
 {result}
 
 Dependencies:
@@ -408,7 +408,7 @@ Outputs:
             secs = duration.total_seconds()
             hours, remainder = divmod(secs, 3600)
             minutes, seconds = divmod(remainder, 60)
-            duration = '%d:%d:%.1f' % (hours, minutes, seconds)
+            duration = '%02d:%02d:%04.1f' % (hours, minutes, seconds)
 
             parameters = self._dict_to_indented_list(ent['config'])
 
@@ -453,13 +453,20 @@ Outputs:
                 assert type(query), QueryImpl
                 q = query
             elif exp_name:
-                q = Query().experiment.name.matches(exp_name)
+                q = Query().experiment.name.search(exp_name)
     
             entries = self.runs.search(q)
     
-        elif indices:
+        elif indices or indices == 0:
             if not isinstance(indices, (tuple, list)):
                 indices = [indices]
+
+            num_recs = len(self.runs)
+
+            for idx in indices:
+                if idx >= num_recs:
+                    raise ValueError('Index value ({}) must be less than '
+                            'number of records ({})'.format(idx, num_recs))
 
             entries = [self.runs.all()[ind] for ind in indices]
 

--- a/sacred/observers/tinydb_hashfs.py
+++ b/sacred/observers/tinydb_hashfs.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
-from __future__ import division, print_function, unicode_literals
+from __future__ import (division, print_function, unicode_literals, 
+                        absolute_import)
 
 import os
 import datetime as dt
@@ -13,7 +14,7 @@ from sacred.dependencies import get_digest
 import sacred.optional as opt
 
 from tinydb import TinyDB
-from hashFS import HashFS
+from hashfs import HashFS
 from tinydb_serialization import Serializer, SerializationMiddleware
 
 __sacred__ = True  # marks files that should be filtered from stack traces

--- a/sacred/observers/tinydb_hashfs.py
+++ b/sacred/observers/tinydb_hashfs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-from __future__ import (division, print_function, unicode_literals, 
+from __future__ import (division, print_function, unicode_literals,
                         absolute_import)
 
 import os

--- a/sacred/observers/tinydb_hashfs.py
+++ b/sacred/observers/tinydb_hashfs.py
@@ -146,15 +146,16 @@ class TinyDbObserver(RunObserver):
         db = TinyDB(os.path.join(root_dir, 'metadata.json'),
                     storage=serialization_store)
 
-        return TinyDbObserver(db, fs, overwrite=overwrite)
+        return TinyDbObserver(db, fs, overwrite=overwrite, root=root_dir)
 
-    def __init__(self, db, fs, overwrite=None):
+    def __init__(self, db, fs, overwrite=None, root=None):
         self.db = db
         self.runs = db.table('runs')
         self.fs = fs
         self.overwrite = overwrite
         self.run_entry = {}
         self.db_run_id = None
+        self.root = root
 
     def save(self):
         """Insert or update the current run entry."""
@@ -176,7 +177,7 @@ class TinyDbObserver(RunObserver):
 
             file = self.fs.get(md5)
             if file:
-                id_ = file.id                
+                id_ = file.id
             else:
                 address = self.fs.put(abs_path)
                 id_ = address.id
@@ -341,18 +342,18 @@ class TinyDbReader(object):
 
         """
 
-        entries = self.fetch_metadata(exp_name, query, indices) 
+        entries = self.fetch_metadata(exp_name, query, indices)
 
         all_matched_entries = []
         for ent in entries:
-            
-            rec = dict(exp_name=ent['experiment']['name'], 
+
+            rec = dict(exp_name=ent['experiment']['name'],
                        exp_id=ent['_id'], 
                        date=ent['start_time'])
 
             source_files = {x[0]: x[2] for x in ent['experiment']['sources']}
             resource_files = {x[0]: x[2] for x in ent['resources']}
-            artifact_files = {x[0]: x[3] for x in ent['artifacts']}            
+            artifact_files = {x[0]: x[3] for x in ent['artifacts']}
 
             if source_files:
                 rec['sources'] = source_files
@@ -397,7 +398,7 @@ Outputs:
 
         all_matched_entries = []
         for ent in entries:
-            
+
             date = ent['start_time']
             WEEKDAYS = 'Mon Tue Wed Thu Fri Sat Sun'.split()
             w = WEEKDAYS[date.weekday()]
@@ -481,5 +482,3 @@ Outputs:
         output_str = textwrap.indent(output_str.strip(), prefix='    ')
 
         return output_str
-
-

--- a/sacred/observers/tinydb_hashfs.py
+++ b/sacred/observers/tinydb_hashfs.py
@@ -247,4 +247,4 @@ class TinyDbOption(CommandLineOption):
         if not tail:
             tail = 'observer_db'
 
-        return head, tail 
+        return head, tail

--- a/sacred/observers/tinydb_hashfs.py
+++ b/sacred/observers/tinydb_hashfs.py
@@ -31,7 +31,6 @@ ndarray_type = opt.np.ndarray if opt.has_numpy else None
 
 
 class BufferedReaderWrapper(BufferedReader):
-
     """Custom wrapper to allow for copying of file handle.
 
     tinydb_serialisation currently does a deepcopy on all the content of the
@@ -322,7 +321,7 @@ class TinyDbReader(object):
         self.fs = fs
 
     def search(self, *args, **kwargs):
-        """Wrapper to TinyDB's search function"""
+        """Wrapper to TinyDB's search function."""
         return self.runs.search(*args, **kwargs)
 
     def fetch_files(self, exp_name=None, query=None, indices=None):
@@ -341,7 +340,6 @@ class TinyDbReader(object):
             }
 
         """
-
         entries = self.fetch_metadata(exp_name, query, indices)
 
         all_matched_entries = []
@@ -400,8 +398,8 @@ Outputs:
         for ent in entries:
 
             date = ent['start_time']
-            WEEKDAYS = 'Mon Tue Wed Thu Fri Sat Sun'.split()
-            w = WEEKDAYS[date.weekday()]
+            weekdays = 'Mon Tue Wed Thu Fri Sat Sun'.split()
+            w = weekdays[date.weekday()]
             date = ' '.join([w, date.strftime('%d %b %Y')])
 
             duration = ent['stop_time'] - ent['start_time']
@@ -446,8 +444,7 @@ Outputs:
         return all_matched_entries
 
     def fetch_metadata(self, exp_name=None, query=None, indices=None):
-        """Return all metadata for matching experiment name, index or query"""
-
+        """Return all metadata for matching experiment name, index or query."""
         if exp_name or query:
             if query:
                 assert type(query), QueryImpl

--- a/sacred/observers/tinydb_hashfs.py
+++ b/sacred/observers/tinydb_hashfs.py
@@ -10,6 +10,7 @@ import uuid
 
 from sacred.__about__ import __version__
 from sacred.observers import RunObserver
+from sacred.commandline_options import CommandLineOption
 from sacred.dependencies import get_digest
 import sacred.optional as opt
 
@@ -220,3 +221,30 @@ class TinyDbObserver(RunObserver):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+
+class TinyDbOption(CommandLineOption):
+    """Add a TinyDB Observer to the experiment."""
+
+    arg = 'LOCATION'
+    arg_description = ("Root location and name for Tinydb-hash file system. "
+                       "Can be [path/to/location/]db_name defaulting to "
+                       "current directory with db named 'observer_db'")
+
+    @classmethod
+    def apply(cls, args, run):
+        location, db_name = cls.parse_tinydb_arg(args)
+        tinydb_obs = TinyDbObserver.create(path=location, name=db_name)
+        run.observers.append(tinydb_obs)
+
+    @classmethod
+    def parse_tinydb_arg(cls, args):
+
+        head, tail = os.path.split(args)
+
+        if not head:
+            head = '.'
+        if not tail:
+            tail = 'observer_db'
+
+        return head, tail 

--- a/sacred/serializer.py
+++ b/sacred/serializer.py
@@ -18,6 +18,7 @@ class DatetimeHandler(jsonpickle.handlers.BaseHandler):
     def flatten(self, obj, data):
         return obj.isoformat()
 
+
 DatetimeHandler.handles(datetime)
 
 json.set_encoder_options('simplejson', sort_keys=True, indent=4)

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python
+# coding=utf-8
+from __future__ import division, print_function, unicode_literals
+
+import datetime
+
+import mock
+# import mongomock
+import pytest
+import tempfile
+
+from tinydb import Query
+
+from sacred.dependencies import get_digest
+from sacred.observers.tinydb import TinyDbObserver
+from sacred import optional as opt
+
+T1 = datetime.datetime(1999, 5, 4, 3, 2, 1, 0)
+T2 = datetime.datetime(1999, 5, 5, 5, 5, 5, 5)
+
+
+@pytest.fixture()
+def tinydb_obs(tmpdir):
+    return TinyDbObserver.create(path=tmpdir.strpath, name='testdb')
+
+
+@pytest.fixture()
+def sample_run():
+    exp = {'name': 'test_exp', 'sources': [], 'doc': '', 'base_dir': '/tmp'}
+    host = {'hostname': 'test_host', 'cpu_count': 1, 'python_version': '3.4'}
+    config = {'config': 'True', 'foo': 'bar', 'answer': 42}
+    command = 'run'
+    meta_info = {'comment': 'test run'}
+    return {
+        '_id': 'FEDCBA9876543210',
+        'ex_info': exp,
+        'command': command,
+        'host_info': host,
+        'start_time': T1,
+        'config': config,
+        'meta_info': meta_info,
+    }
+
+
+# def test_tindb_observer_started_event_creates_run(tinydb_obs, sample_run):
+#     sample_run['_id'] = None
+#     _id = tinydb_obs.started_event(**sample_run)
+#     assert _id is not None
+#     assert len(tinydb_obs.runs) == 1
+#     db_run = tinydb_obs.runs.get(eid=1)
+#     assert db_run == {
+#         '_id': _id,
+#         'experiment': sample_run['ex_info'],
+#         'format': tinydb_obs.VERSION,
+#         'command': sample_run['command'],
+#         'host': sample_run['host_info'],
+#         'start_time': sample_run['start_time'],
+#         'heartbeat': None,
+#         'info': {},
+#         'captured_out': '',
+#         'artifacts': [],
+#         'config': sample_run['config'],
+#         'meta': sample_run['meta_info'],
+#         'status': 'RUNNING',
+#         'resources': []
+#     }
+
+
+def test_tinydb_observer_started_event_uses_given_id(tinydb_obs, sample_run):
+    _id = tinydb_obs.started_event(**sample_run)
+    assert _id == sample_run['_id']
+    assert len(tinydb_obs.runs) == 1
+    db_run = tinydb_obs.runs.get(eid=1)
+    assert db_run['_id'] == sample_run['_id']
+
+
+# # Got to here !!!!
+# def test_mongo_observer_equality(mongo_obs):
+#     runs = mongo_obs.runs
+#     fs = mock.MagicMock()
+#     m = TinyDbObserver(runs, fs)
+#     assert mongo_obs == m
+#     assert not mongo_obs != m
+
+#     assert not mongo_obs == 'foo'
+#     assert mongo_obs != 'foo'
+
+
+# def test_mongo_observer_heartbeat_event_updates_run(mongo_obs, sample_run):
+#     mongo_obs.started_event(**sample_run)
+
+#     info = {'my_info': [1, 2, 3], 'nr': 7}
+#     outp = 'some output'
+#     with tempfile.NamedTemporaryFile() as f:
+#         f.write(outp.encode())
+#         f.flush()
+#         mongo_obs.heartbeat_event(info=info, cout_filename=f.name,
+#                                   beat_time=T2)
+
+#     assert mongo_obs.runs.count() == 1
+#     db_run = mongo_obs.runs.find_one()
+#     assert db_run['heartbeat'] == T2
+#     assert db_run['info'] == info
+#     assert db_run['captured_out'] == outp
+
+
+# def test_mongo_observer_completed_event_updates_run(mongo_obs, sample_run):
+#     mongo_obs.started_event(**sample_run)
+
+#     mongo_obs.completed_event(stop_time=T2, result=42)
+
+#     assert mongo_obs.runs.count() == 1
+#     db_run = mongo_obs.runs.find_one()
+#     assert db_run['stop_time'] == T2
+#     assert db_run['result'] == 42
+#     assert db_run['status'] == 'COMPLETED'
+
+
+# def test_mongo_observer_interrupted_event_updates_run(mongo_obs, sample_run):
+#     mongo_obs.started_event(**sample_run)
+
+#     mongo_obs.interrupted_event(interrupt_time=T2, status='INTERRUPTED')
+
+#     assert mongo_obs.runs.count() == 1
+#     db_run = mongo_obs.runs.find_one()
+#     assert db_run['stop_time'] == T2
+#     assert db_run['status'] == 'INTERRUPTED'
+
+
+# def test_mongo_observer_failed_event_updates_run(mongo_obs, sample_run):
+#     mongo_obs.started_event(**sample_run)
+
+#     fail_trace = "lots of errors and\nso\non..."
+#     mongo_obs.failed_event(fail_time=T2,
+#                            fail_trace=fail_trace)
+
+#     assert mongo_obs.runs.count() == 1
+#     db_run = mongo_obs.runs.find_one()
+#     assert db_run['stop_time'] == T2
+#     assert db_run['status'] == 'FAILED'
+#     assert db_run['fail_trace'] == fail_trace
+
+
+# def test_mongo_observer_artifact_event(mongo_obs, sample_run):
+#     mongo_obs.started_event(**sample_run)
+
+#     filename = "setup.py"
+#     name = 'mysetup'
+
+#     mongo_obs.artifact_event(name, filename)
+
+#     assert mongo_obs.fs.put.called
+#     assert mongo_obs.fs.put.call_args[1]['filename'].endswith(name)
+
+#     db_run = mongo_obs.runs.find_one()
+#     assert db_run['artifacts']
+
+
+# def test_mongo_observer_resource_event(mongo_obs, sample_run):
+#     mongo_obs.started_event(**sample_run)
+
+#     filename = "setup.py"
+#     md5 = get_digest(filename)
+
+#     mongo_obs.resource_event(filename)
+
+#     assert mongo_obs.fs.exists.called
+#     mongo_obs.fs.exists.assert_any_call(filename=filename)
+
+#     db_run = mongo_obs.runs.find_one()
+#     assert db_run['resources'] == [(filename, md5)]
+
+
+# def test_force_bson_encodable_doesnt_change_valid_document():
+#     d = {'int': 1, 'string': 'foo', 'float': 23.87, 'list': ['a', 1, True],
+#          'bool': True, 'cr4zy: _but_ [legal) Key!': '$illegal.key.as.value',
+#          'datetime': datetime.datetime.now(), 'tuple': (1, 2.0, 'three'),
+#          'none': None}
+#     assert force_bson_encodeable(d) == d
+
+
+# def test_force_bson_encodable_substitutes_illegal_value_with_strings():
+#     d = {
+#         'a_module': datetime,
+#         'some_legal_stuff': {'foo': 'bar', 'baz': [1, 23, 4]},
+#         'nested': {
+#             'dict': {
+#                 'with': {
+#                     'illegal_module': mock
+#                 }
+#             }
+#         },
+#         '$illegal': 'because it starts with a $',
+#         'il.legal': 'because it contains a .',
+#         12.7: 'illegal because it is not a string key'
+#     }
+#     expected = {
+#         'a_module': str(datetime),
+#         'some_legal_stuff': {'foo': 'bar', 'baz': [1, 23, 4]},
+#         'nested': {
+#             'dict': {
+#                 'with': {
+#                     'illegal_module': str(mock)
+#                 }
+#             }
+#         },
+#         '@illegal': 'because it starts with a $',
+#         'il,legal': 'because it contains a .',
+#         '12,7': 'illegal because it is not a string key'
+#     }
+#     assert force_bson_encodeable(d) == expected
+
+
+# @pytest.mark.skipif(not opt.has_numpy, reason='needs numpy')
+# def test_numpy_array_to_list_son_manipulator():
+#     from sacred.observers.mongo import NumpyArraysToList
+#     import numpy as np
+#     sonm = NumpyArraysToList()
+#     document = {
+#         'foo': 'bar',
+#         'some_array': np.eye(3),
+#         'nested': {
+#             'ones': np.ones(5)
+#         }
+#     }
+#     mod_doc = sonm.transform_incoming(document, 'fake_collection')
+#     assert mod_doc['foo'] == 'bar'
+#     assert mod_doc['some_array'] == [[1.0, 0.0, 0.0],
+#                                      [0.0, 1.0, 0.0],
+#                                      [0.0, 0.0, 1.0]]
+#     assert mod_doc['nested']['ones'] == [1.0, 1.0, 1.0, 1.0, 1.0]
+
+
+# @pytest.mark.skipif(not opt.has_pandas, reason='needs pandas')
+# def test_pandas_to_json_son_manipulator():
+#     from sacred.observers.mongo import PandasToJson
+#     import numpy as np
+#     import pandas as pd
+#     sonm = PandasToJson()
+#     document = {
+#         'foo': 'bar',
+#         'some_array': pd.DataFrame(np.eye(3), columns=list('ABC')),
+#         'nested': {
+#             'ones': pd.Series(np.ones(5))
+#         }
+#     }
+#     mod_doc = sonm.transform_incoming(document, 'fake_collection')
+#     assert mod_doc['foo'] == 'bar'
+#     assert mod_doc['some_array'] == {'A': {'0': 1.0, '1': 0.0, '2': 0.0},
+#                                      'B': {'0': 0.0, '1': 1.0, '2': 0.0},
+#                                      'C': {'0': 0.0, '1': 0.0, '2': 1.0}}
+#     assert mod_doc['nested']['ones'] == {"0": 1.0, "1": 1.0, "2": 1.0,
+#                                          "3": 1.0, "4": 1.0}

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -45,7 +45,7 @@ def sample_run():
     }
 
 
-def test_tindb_observer_started_event_creates_run(tinydb_obs, sample_run):
+def test_tinydb_observer_started_event_creates_run(tinydb_obs, sample_run):
     sample_run['_id'] = None
     _id = tinydb_obs.started_event(**sample_run)
     assert _id is not None
@@ -77,7 +77,7 @@ def test_tinydb_observer_started_event_uses_given_id(tinydb_obs, sample_run):
     assert db_run['_id'] == sample_run['_id']
 
 
-def test_tindb_observer_started_event_saves_given_sources(tinydb_obs,
+def test_tinydb_observer_started_event_saves_given_sources(tinydb_obs,
                                                           sample_run):
 
     filename = 'setup.py'
@@ -123,7 +123,7 @@ def test_tindb_observer_started_event_saves_given_sources(tinydb_obs,
     assert db_run['experiment']['sources'][0][:2] == db_run2['experiment']['sources'][0][:2]
 
 
-def test_tindb_observer_started_event_generates_different_run_ids(tinydb_obs,
+def test_tinydb_observer_started_event_generates_different_run_ids(tinydb_obs,
                                                                   sample_run):
     sample_run['_id'] = None
     _id = tinydb_obs.started_event(**sample_run)

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -8,12 +8,12 @@ import tempfile
 
 import pytest
 
-from sacred.dependencies import get_digest
-from sacred.observers.tinydb import TinyDbObserver
-from sacred import optional as opt
-
 from tinydb import TinyDB
 from hashfs import HashFS
+
+from sacred.dependencies import get_digest
+from sacred.observers.tinydb_hashfs import TinyDbObserver
+from sacred import optional as opt
 
 T1 = datetime.datetime(1999, 5, 4, 3, 2, 1, 0)
 T2 = datetime.datetime(1999, 5, 5, 5, 5, 5, 5)
@@ -143,7 +143,7 @@ def test_tinydb_observer_equality(tmpdir, tinydb_obs):
 
     db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'))
     fs = HashFS(os.path.join(tmpdir.strpath, 'hashfs'), depth=3, 
-                width=2, algorithm='md5')
+                       width=2, algorithm='md5')
     m = TinyDbObserver(db, fs)
 
     assert tinydb_obs == m

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -8,12 +8,12 @@ import tempfile
 
 import pytest
 
-from tinydb import TinyDB
-from hashfs import HashFS
-
 from sacred.dependencies import get_digest
 from sacred.observers.tinydb import TinyDbObserver
 from sacred import optional as opt
+
+from tinydb import TinyDB
+from hashfs import HashFS
 
 T1 = datetime.datetime(1999, 5, 4, 3, 2, 1, 0)
 T2 = datetime.datetime(1999, 5, 5, 5, 5, 5, 5)

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -2,12 +2,11 @@
 # coding=utf-8
 from __future__ import division, print_function, unicode_literals
 
-import datetime
-
 import os
+import datetime
+import tempfile
 
 import pytest
-import tempfile
 
 from tinydb import TinyDB
 from hashfs import HashFS

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -74,7 +74,8 @@ def test_tinydb_observer_started_event_uses_given_id(tinydb_obs, sample_run):
     assert db_run['_id'] == sample_run['_id']
 
 
-def test_tindb_observer_started_event_saves_given_sources(tinydb_obs, sample_run):
+def test_tindb_observer_started_event_saves_given_sources(tinydb_obs, 
+                                                          sample_run):
 
     filename = 'setup.py'
     md5 = get_digest(filename)
@@ -110,7 +111,8 @@ def test_tindb_observer_started_event_saves_given_sources(tinydb_obs, sample_run
     assert db_run2['experiment']['sources'] == db_run['experiment']['sources']
 
 
-def test_tindb_observer_started_event_generates_different_run_ids(tinydb_obs, sample_run):
+def test_tindb_observer_started_event_generates_different_run_ids(tinydb_obs,
+                                                                  sample_run):
     sample_run['_id'] = None
     _id = tinydb_obs.started_event(**sample_run)
     assert _id is not None
@@ -125,7 +127,8 @@ def test_tindb_observer_started_event_generates_different_run_ids(tinydb_obs, sa
     assert _id != _id2
 
 
-def test_tinydb_observer_queued_event_is_not_implimented(tinydb_obs, sample_run):
+def test_tinydb_observer_queued_event_is_not_implimented(tinydb_obs, 
+                                                         sample_run):
 
     sample_queued_run = sample_run.copy()
     del sample_queued_run['host_info']
@@ -139,7 +142,8 @@ def test_tinydb_observer_queued_event_is_not_implimented(tinydb_obs, sample_run)
 def test_tinydb_observer_equality(tmpdir, tinydb_obs):
 
     db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'))
-    fs = HashFS(os.path.join(tmpdir.strpath, 'hashfs'), depth=3, width=2, algorithm='md5')
+    fs = HashFS(os.path.join(tmpdir.strpath, 'hashfs'), depth=3, 
+                width=2, algorithm='md5')
     m = TinyDbObserver(db, fs)
 
     assert tinydb_obs == m
@@ -179,7 +183,8 @@ def test_tinydb_observer_completed_event_updates_run(tinydb_obs, sample_run):
     assert db_run['status'] == 'COMPLETED'
 
 
-def test_tinydb_observer_interrupted_event_updates_run(tinydb_obs, sample_run):
+def test_tinydb_observer_interrupted_event_updates_run(tinydb_obs, 
+                                                       sample_run):
     tinydb_obs.started_event(**sample_run)
 
     tinydb_obs.interrupted_event(interrupt_time=T2, status='INTERRUPTED')
@@ -248,7 +253,8 @@ def test_tinydb_observer_resource_event(tinydb_obs, sample_run):
     assert fs_content == file_content
 
 
-def test_tinydb_observer_resource_event_when_resource_present(tinydb_obs, sample_run):
+def test_tinydb_observer_resource_event_when_resource_present(tinydb_obs, 
+                                                              sample_run):
     tinydb_obs.started_event(**sample_run)
 
     filename = "setup.py"
@@ -273,7 +279,8 @@ def test_serialisation_of_numpy_ndarray(tmpdir):
     serialization_store = SerializationMiddleware()
     serialization_store.register_serializer(NdArraySerializer(), 'TinyArray')
 
-    db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'), storage=serialization_store)
+    db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'), 
+                storage=serialization_store)
 
     eye_mat = np.eye(3)
     ones_array = np.ones(5)
@@ -304,10 +311,13 @@ def test_pandas_to_json_son_manipulator(tmpdir):
 
     # Setup Serialisation object for non list/dict objects 
     serialization_store = SerializationMiddleware()
-    serialization_store.register_serializer(DataFrameSerializer(), 'TinyDataFrame')
-    serialization_store.register_serializer(SeriesSerializer(), 'TinySeries')
+    serialization_store.register_serializer(DataFrameSerializer(), 
+                                            'TinyDataFrame')
+    serialization_store.register_serializer(SeriesSerializer(), 
+                                            'TinySeries')
 
-    db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'), storage=serialization_store)
+    db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'), 
+                storage=serialization_store)
 
     df = pd.DataFrame(np.eye(3), columns=list('ABC'))
     series = pd.Series(np.ones(5))

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-from __future__ import (division, print_function, unicode_literals, 
+from __future__ import (division, print_function, unicode_literals,
                         absolute_import)
 
 import os

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -15,6 +15,7 @@ from hashfs import HashFS
 from sacred.dependencies import get_digest
 from sacred.observers.tinydb_hashfs import TinyDbObserver, TinyDbOption
 from sacred import optional as opt
+from sacred.experiment import Experiment
 
 T1 = datetime.datetime(1999, 5, 4, 3, 2, 1, 0)
 T2 = datetime.datetime(1999, 5, 5, 5, 5, 5, 5)
@@ -340,7 +341,16 @@ def test_serialisation_of_pandas_dataframe(tmpdir):
     assert (returned_doc['nested']['ones'] == series).all()
 
 
-def test_parse_mongo_db_arg():
+def test_parse_tinydb_arg():
     assert TinyDbOption.parse_tinydb_arg('foo') == ('.', 'foo')
     assert TinyDbOption.parse_tinydb_arg('path/to/foo') == ('path/to', 'foo')
     assert TinyDbOption.parse_tinydb_arg('') == ('.', 'observer_db')
+
+
+def test_parse_tinydboption_apply(tmpdir):
+
+    exp = Experiment()
+    args = (os.path.join(tmpdir.strpath, 'testdb'))  
+
+    TinyDbOption.apply(args, exp) 
+    assert type(exp.observers[0]) == TinyDbObserver

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -13,7 +13,7 @@ from tinydb import TinyDB
 from hashfs import HashFS
 
 from sacred.dependencies import get_digest
-from sacred.observers.tinydb_hashfs import TinyDbObserver
+from sacred.observers.tinydb_hashfs import TinyDbObserver, TinyDbOption
 from sacred import optional as opt
 
 T1 = datetime.datetime(1999, 5, 4, 3, 2, 1, 0)
@@ -338,3 +338,9 @@ def test_serialisation_of_pandas_dataframe(tmpdir):
     assert returned_doc['foo'] == 'bar'
     assert (returned_doc['some_dataframe'] == df).all().all()
     assert (returned_doc['nested']['ones'] == series).all()
+
+
+def test_parse_mongo_db_arg():
+    assert TinyDbOption.parse_tinydb_arg('foo') == ('.', 'foo')
+    assert TinyDbOption.parse_tinydb_arg('path/to/foo') == ('path/to', 'foo')
+    assert TinyDbOption.parse_tinydb_arg('') == ('.', 'observer_db')

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -23,7 +23,7 @@ T2 = datetime.datetime(1999, 5, 5, 5, 5, 5, 5)
 
 @pytest.fixture()
 def tinydb_obs(tmpdir):
-    return TinyDbObserver.create(path=tmpdir.strpath, name='testdb')
+    return TinyDbObserver.create(path=tmpdir.strpath)
 
 
 @pytest.fixture()
@@ -342,15 +342,13 @@ def test_serialisation_of_pandas_dataframe(tmpdir):
 
 
 def test_parse_tinydb_arg():
-    assert TinyDbOption.parse_tinydb_arg('foo') == ('.', 'foo')
-    assert TinyDbOption.parse_tinydb_arg('path/to/foo') == ('path/to', 'foo')
-    assert TinyDbOption.parse_tinydb_arg('') == ('.', 'observer_db')
+    assert TinyDbOption.parse_tinydb_arg('foo') == 'foo'
 
 
 def test_parse_tinydboption_apply(tmpdir):
 
     exp = Experiment()
-    args = (os.path.join(tmpdir.strpath, 'testdb'))  
+    args = os.path.join(tmpdir.strpath)  
 
     TinyDbOption.apply(args, exp) 
     assert type(exp.observers[0]) == TinyDbObserver

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -14,7 +14,8 @@ from tinydb import TinyDB
 from hashfs import HashFS
 
 from sacred.dependencies import get_digest
-from sacred.observers.tinydb_hashfs import TinyDbObserver, TinyDbOption, BufferedReaderWrapper
+from sacred.observers.tinydb_hashfs import (TinyDbObserver, TinyDbOption, 
+                                            BufferedReaderWrapper)
 from sacred import optional as opt
 from sacred.experiment import Experiment
 
@@ -124,7 +125,8 @@ def test_tinydb_observer_started_event_saves_given_sources(tinydb_obs,
     assert len(tinydb_obs.runs) == 2
     db_run2 = tinydb_obs.runs.get(eid=2)
 
-    assert db_run['experiment']['sources'][0][:2] == db_run2['experiment']['sources'][0][:2]
+    assert (db_run['experiment']['sources'][0][:2] ==
+            db_run2['experiment']['sources'][0][:2])
 
 
 def test_tinydb_observer_started_event_generates_different_run_ids(tinydb_obs,
@@ -282,7 +284,7 @@ def test_custom_bufferreaderwrapper(tmpdir):
 
     with open(os.path.join(tmpdir.strpath, 'test.txt'), 'w') as f:
         f.write('some example text')
-    with open(os.path.join(tmpdir.strpath, 'test.txt'), 'r') as f:
+    with open(os.path.join(tmpdir.strpath, 'test.txt'), 'rb') as f:
         custom_fh = BufferedReaderWrapper(f)
         assert f.name == custom_fh.name
         assert f.mode == custom_fh.mode
@@ -291,7 +293,7 @@ def test_custom_bufferreaderwrapper(tmpdir):
         assert custom_fh.mode == custom_fh_copy.mode
 
     assert f.closed
-    assert custom_fh.closed
+    assert not custom_fh.closed
     assert not custom_fh_copy.closed
 
     custom_fh_deepcopy = copy.deepcopy(custom_fh_copy)

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -75,7 +75,7 @@ def test_tinydb_observer_started_event_uses_given_id(tinydb_obs, sample_run):
     assert db_run['_id'] == sample_run['_id']
 
 
-def test_tindb_observer_started_event_saves_given_sources(tinydb_obs, 
+def test_tindb_observer_started_event_saves_given_sources(tinydb_obs,
                                                           sample_run):
 
     filename = 'setup.py'
@@ -128,7 +128,7 @@ def test_tindb_observer_started_event_generates_different_run_ids(tinydb_obs,
     assert _id != _id2
 
 
-def test_tinydb_observer_queued_event_is_not_implimented(tinydb_obs, 
+def test_tinydb_observer_queued_event_is_not_implimented(tinydb_obs,
                                                          sample_run):
 
     sample_queued_run = sample_run.copy()
@@ -143,8 +143,8 @@ def test_tinydb_observer_queued_event_is_not_implimented(tinydb_obs,
 def test_tinydb_observer_equality(tmpdir, tinydb_obs):
 
     db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'))
-    fs = HashFS(os.path.join(tmpdir.strpath, 'hashfs'), depth=3, 
-                       width=2, algorithm='md5')
+    fs = HashFS(os.path.join(tmpdir.strpath, 'hashfs'), depth=3,
+                width=2, algorithm='md5')
     m = TinyDbObserver(db, fs)
 
     assert tinydb_obs == m
@@ -184,7 +184,7 @@ def test_tinydb_observer_completed_event_updates_run(tinydb_obs, sample_run):
     assert db_run['status'] == 'COMPLETED'
 
 
-def test_tinydb_observer_interrupted_event_updates_run(tinydb_obs, 
+def test_tinydb_observer_interrupted_event_updates_run(tinydb_obs,
                                                        sample_run):
     tinydb_obs.started_event(**sample_run)
 
@@ -254,7 +254,7 @@ def test_tinydb_observer_resource_event(tinydb_obs, sample_run):
     assert fs_content == file_content
 
 
-def test_tinydb_observer_resource_event_when_resource_present(tinydb_obs, 
+def test_tinydb_observer_resource_event_when_resource_present(tinydb_obs,
                                                               sample_run):
     tinydb_obs.started_event(**sample_run)
 
@@ -272,15 +272,15 @@ def test_tinydb_observer_resource_event_when_resource_present(tinydb_obs,
 
 @pytest.mark.skipif(not opt.has_numpy, reason='needs numpy')
 def test_serialisation_of_numpy_ndarray(tmpdir):
-    from sacred.observers.tinydb import NdArraySerializer
+    from sacred.observers.tinydb_hashfs import NdArraySerializer
     from tinydb_serialization import SerializationMiddleware
     import numpy as np
 
-    # Setup Serialisation object for non list/dict objects 
+    # Setup Serialisation object for non list/dict objects
     serialization_store = SerializationMiddleware()
     serialization_store.register_serializer(NdArraySerializer(), 'TinyArray')
 
-    db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'), 
+    db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'),
                 storage=serialization_store)
 
     eye_mat = np.eye(3)
@@ -303,21 +303,22 @@ def test_serialisation_of_numpy_ndarray(tmpdir):
 
 
 @pytest.mark.skipif(not opt.has_pandas, reason='needs pandas')
-def test_pandas_to_json_son_manipulator(tmpdir):
-    from sacred.observers.tinydb import DataFrameSerializer, SeriesSerializer
+def test_serialisation_of_pandas_dataframe(tmpdir):
+    from sacred.observers.tinydb_hashfs import (DataFrameSerializer, 
+                                                SeriesSerializer)
     from tinydb_serialization import SerializationMiddleware
 
     import numpy as np
     import pandas as pd
 
-    # Setup Serialisation object for non list/dict objects 
+    # Setup Serialisation object for non list/dict objects
     serialization_store = SerializationMiddleware()
-    serialization_store.register_serializer(DataFrameSerializer(), 
+    serialization_store.register_serializer(DataFrameSerializer(),
                                             'TinyDataFrame')
-    serialization_store.register_serializer(SeriesSerializer(), 
+    serialization_store.register_serializer(SeriesSerializer(),
                                             'TinySeries')
 
-    db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'), 
+    db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'),
                 storage=serialization_store)
 
     df = pd.DataFrame(np.eye(3), columns=list('ABC'))

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
-from __future__ import division, print_function, unicode_literals
+from __future__ import (division, print_function, unicode_literals, 
+                        absolute_import)
 
 import os
 import datetime

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -42,28 +42,28 @@ def sample_run():
     }
 
 
-# def test_tindb_observer_started_event_creates_run(tinydb_obs, sample_run):
-#     sample_run['_id'] = None
-#     _id = tinydb_obs.started_event(**sample_run)
-#     assert _id is not None
-#     assert len(tinydb_obs.runs) == 1
-#     db_run = tinydb_obs.runs.get(eid=1)
-#     assert db_run == {
-#         '_id': _id,
-#         'experiment': sample_run['ex_info'],
-#         'format': tinydb_obs.VERSION,
-#         'command': sample_run['command'],
-#         'host': sample_run['host_info'],
-#         'start_time': sample_run['start_time'],
-#         'heartbeat': None,
-#         'info': {},
-#         'captured_out': '',
-#         'artifacts': [],
-#         'config': sample_run['config'],
-#         'meta': sample_run['meta_info'],
-#         'status': 'RUNNING',
-#         'resources': []
-#     }
+def test_tindb_observer_started_event_creates_run(tinydb_obs, sample_run):
+    sample_run['_id'] = None
+    _id = tinydb_obs.started_event(**sample_run)
+    assert _id is not None
+    assert len(tinydb_obs.runs) == 1
+    db_run = tinydb_obs.runs.get(eid=1)
+    assert db_run == {
+        '_id': _id,
+        'experiment': sample_run['ex_info'],
+        'format': tinydb_obs.VERSION,
+        'command': sample_run['command'],
+        'host': sample_run['host_info'],
+        'start_time': sample_run['start_time'],
+        'heartbeat': None,
+        'info': {},
+        'captured_out': '',
+        'artifacts': [],
+        'config': sample_run['config'],
+        'meta': sample_run['meta_info'],
+        'status': 'RUNNING',
+        'resources': []
+    }
 
 
 def test_tinydb_observer_started_event_uses_given_id(tinydb_obs, sample_run):

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -103,12 +103,27 @@ def test_tindb_observer_started_event_saves_given_sources(tinydb_obs, sample_run
         'resources': []
     }
 
-    # Check that duplicate source files are listed in ex_info
+    # Check that duplicate source files are still listed in ex_info
     tinydb_obs.db_run_id = None
-    _id2 = tinydb_obs.started_event(**sample_run)
+    tinydb_obs.started_event(**sample_run)
     assert len(tinydb_obs.runs) == 2
     db_run2 = tinydb_obs.runs.get(eid=2)
     assert db_run2['experiment']['sources'] == db_run['experiment']['sources']
+
+
+def test_tindb_observer_started_event_generates_different_run_ids(tinydb_obs, sample_run):
+    sample_run['_id'] = None
+    _id = tinydb_obs.started_event(**sample_run)
+    assert _id is not None
+
+    # Check that duplicate source files are still listed in ex_info
+    tinydb_obs.db_run_id = None
+    sample_run['_id'] = None
+    _id2 = tinydb_obs.started_event(**sample_run)
+
+    assert len(tinydb_obs.runs) == 2
+    # Check new random id is given for each run
+    assert _id != _id2
 
 
 def test_tinydb_observer_queued_event_is_not_implimented(tinydb_obs, sample_run):

--- a/tests/test_observers/test_tinydb_reader.py
+++ b/tests/test_observers/test_tinydb_reader.py
@@ -10,7 +10,7 @@ import io
 
 import pytest
 
-from tinydb import TinyDB
+from tinydb import TinyDB, Query
 from hashfs import HashFS
 
 from sacred.dependencies import get_digest
@@ -18,37 +18,52 @@ from sacred.observers.tinydb_hashfs import TinyDbObserver, TinyDbReader
 from sacred import optional as opt
 from sacred.experiment import Experiment
 
-T1 = datetime.datetime(1999, 5, 4, 3, 2, 1, 0)
-T2 = datetime.datetime(1999, 5, 5, 5, 5, 5, 5)
-
-
-@pytest.fixture()
+# Utilities and fixtures
+@pytest.fixture
 def sample_run():
-    exp = {'name': 'test_exp', 'sources': [], 'doc': '', 'base_dir': '/tmp'}
+
+    T1 = datetime.datetime(1999, 5, 4, 3, 2, 1, 0)
+
+    exp = {'name': 'test_exp', 
+           'sources': [], 
+           'doc': '', 
+           'base_dir': '/tmp', 
+           'dependencies': ['sacred==0.7b0']}
     host = {'hostname': 'test_host', 'cpu_count': 1, 'python_version': '3.4'}
     config = {'config': 'True', 'foo': 'bar', 'answer': 42}
     command = 'run'
     meta_info = {'comment': 'test run'}
-    return {
-        '_id': 'FEDCBA9876543210',
-        'ex_info': exp,
-        'command': command,
-        'host_info': host,
-        'start_time': T1,
-        'config': config,
-        'meta_info': meta_info,
+    sample_run = {
+            '_id': 'FED235DA13',
+            'ex_info': exp,
+            'command': command,
+            'host_info': host,
+            'start_time': T1,
+            'config': config,
+            'meta_info': meta_info,
     }
 
+    filename = 'setup.py'
+    md5 = get_digest(filename)
+    sample_run['ex_info']['sources'] = [[filename, md5]]
 
-@pytest.fixture()
-def tinydb_obs(tmpdir, sample_run):
-    """TindDB Observer with example data"""
+    return sample_run
+
+
+def run_test_experiment(exp_name, exp_id, root_dir):
+
+    T2 = datetime.datetime(1999, 5, 5, 5, 5, 5, 5)
+    T3 = datetime.datetime(1999, 5, 5, 6, 6, 6, 6)
+
+    run_date = sample_run()
+    run_date['ex_info']['name'] = exp_name
+    run_date['_id'] = exp_id
 
     # Create
-    tinydb_obs = TinyDbObserver.create(path=tmpdir.strpath)
+    tinydb_obs = TinyDbObserver.create(path=root_dir)
 
-    # Sample
-    _id = tinydb_obs.started_event(**sample_run)
+    # Start exp 1
+    _id = tinydb_obs.started_event(**run_date)
 
     # Heartbeat
     info = {'my_info': [1, 2, 3], 'nr': 7}
@@ -57,10 +72,10 @@ def tinydb_obs(tmpdir, sample_run):
         f.write(outp.encode())
         f.flush()
         tinydb_obs.heartbeat_event(info=info, cout_filename=f.name,
-                                   beat_time=T2)
+                                    beat_time=T2)
     # Add Artifact
-    filename = "setup.py"
-    name = 'mysetup'
+    filename = "sacred/__about__.py"
+    name = 'about'
     tinydb_obs.artifact_event(name, filename)
 
     # Add Resource
@@ -68,337 +83,260 @@ def tinydb_obs(tmpdir, sample_run):
     tinydb_obs.resource_event(filename)
 
     # Complete
-    tinydb_obs.completed_event(stop_time=T2, result=42)
+    tinydb_obs.completed_event(stop_time=T3, result=42)
 
     return tinydb_obs
 
 
-@pytest.fixture()
-def tinydb_reader(tinydb_obs):
-    return TinyDbReader(tinydb_obs.root)
+def strip_file_handles(results):
+    """Return a database result set with all file handle objects removed.abs
+    
+    Utility function to aid comparison of database entries. As file handles are
+    created newly each object, these are always different so can be excluded. 
+    """
 
+    if not isinstance(results, (list, tuple)):
+        results = [results]
 
-def test_tinydb_reader_loads_db_and_fs(tinydb_obs, tinydb_reader):
+    cleaned_results = []
+    for result in results:
+        sources = result['experiment']['sources'] 
+        artifacts = result['artifacts']
+        resources = result['resources']
+        if sources:
+            for src in sources:
+                if isinstance(src[-1], io.BufferedReader):
+                    del src[-1]
+        if artifacts:
+            for art in artifacts:
+                if isinstance(art[-1], io.BufferedReader):
+                    del art[-1]
+        if resources:
+            for res in resources:
+                if isinstance(res[-1], io.BufferedReader):
+                    del res[-1]
+        cleaned_results.append(result)
+
+    return cleaned_results
+
+# TinyDbReader Tests
+def test_tinydb_reader_loads_db_and_fs(tmpdir):
+    
+    root = tmpdir.strpath
+    tinydb_obs = run_test_experiment(exp_name='exp1', exp_id='1234', root_dir=root)
+    tinydb_reader = TinyDbReader(root)
+    
     assert tinydb_obs.fs.root == tinydb_reader.fs.root
+    # Different file handles are used in each object so compar based on str 
+    # representation 
     assert str(tinydb_obs.runs.all()[0]) == str(tinydb_reader.runs.all()[0]) 
 
 
-def test_fetch_metadata_function():
-    pass
-
-
-def test_search_function():
-    pass
-
-
-def test_fetch_files_function():
-    pass
-
-
-def test_fetch_report_function():
-    pass
-
-
-
-
-
-#     sample_run['_id'] = None
-#     _id = tinydb_obs.started_event(**sample_run)
-#     assert _id is not None
-#     assert len(tinydb_obs.runs) == 1
-#     db_run = tinydb_obs.runs.get(eid=1)
-#     assert db_run == {
-#         '_id': _id,
-#         'experiment': sample_run['ex_info'],
-#         'format': tinydb_obs.VERSION,
-#         'command': sample_run['command'],
-#         'host': sample_run['host_info'],
-#         'start_time': sample_run['start_time'],
-#         'heartbeat': None,
-#         'info': {},
-#         'captured_out': '',
-#         'artifacts': [],
-#         'config': sample_run['config'],
-#         'meta': sample_run['meta_info'],
-#         'status': 'RUNNING',
-#         'resources': []
-#     }
-
-
-# def test_tindb_observer_started_event_saves_given_sources(tinydb_obs,
-#                                                           sample_run):
-
-#     filename = 'setup.py'
-#     md5 = get_digest(filename)
-
-#     sample_run['ex_info']['sources'] = [[filename, md5]]
-#     _id = tinydb_obs.started_event(**sample_run)
-
-#     assert _id is not None
-#     assert len(tinydb_obs.runs) == 1
-#     db_run = tinydb_obs.runs.get(eid=1)
-
-#     # Check all but the experiment section
-#     db_run_copy = db_run.copy()
-#     del db_run_copy['experiment']
-#     assert db_run_copy == {
-#         '_id': _id,
-#         'format': tinydb_obs.VERSION,
-#         'command': sample_run['command'],
-#         'host': sample_run['host_info'],
-#         'start_time': sample_run['start_time'],
-#         'heartbeat': None,
-#         'info': {},
-#         'captured_out': '',
-#         'artifacts': [],
-#         'config': sample_run['config'],
-#         'meta': sample_run['meta_info'],
-#         'status': 'RUNNING',
-#         'resources': []
-#     }
-
-#     assert len(db_run['experiment']['sources']) == 1
-#     assert len(db_run['experiment']['sources'][0]) == 3
-#     assert db_run['experiment']['sources'][0][:2] == [filename, md5]
-#     assert isinstance(db_run['experiment']['sources'][0][2], io.BufferedReader)
-
-#     # Check that duplicate source files are still listed in ex_info
-#     tinydb_obs.db_run_id = None
-#     tinydb_obs.started_event(**sample_run)
-#     assert len(tinydb_obs.runs) == 2
-#     db_run2 = tinydb_obs.runs.get(eid=2)
-
-#     assert db_run['experiment']['sources'][0][:2] == db_run2['experiment']['sources'][0][:2]
-
-
-# def test_tindb_observer_started_event_generates_different_run_ids(tinydb_obs,
-#                                                                   sample_run):
-#     sample_run['_id'] = None
-#     _id = tinydb_obs.started_event(**sample_run)
-#     assert _id is not None
-
-#     # Check that duplicate source files are still listed in ex_info
-#     tinydb_obs.db_run_id = None
-#     sample_run['_id'] = None
-#     _id2 = tinydb_obs.started_event(**sample_run)
-
-#     assert len(tinydb_obs.runs) == 2
-#     # Check new random id is given for each run
-#     assert _id != _id2
-
-
-# def test_tinydb_observer_queued_event_is_not_implimented(tinydb_obs,
-#                                                          sample_run):
-
-#     sample_queued_run = sample_run.copy()
-#     del sample_queued_run['host_info']
-#     del sample_queued_run['start_time']
-#     sample_queued_run['queue_time'] = T1
-
-#     with pytest.raises(NotImplementedError):
-#         tinydb_obs.queued_event(**sample_queued_run)
-
-
-# def test_tinydb_observer_equality(tmpdir, tinydb_obs):
-
-#     db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'))
-#     fs = HashFS(os.path.join(tmpdir.strpath, 'hashfs'), depth=3,
-#                 width=2, algorithm='md5')
-#     m = TinyDbObserver(db, fs)
-
-#     assert tinydb_obs == m
-#     assert not tinydb_obs != m
-
-#     assert not tinydb_obs == 'foo'
-#     assert tinydb_obs != 'foo'
-
-
-# def test_tinydb_observer_heartbeat_event_updates_run(tinydb_obs, sample_run):
-#     tinydb_obs.started_event(**sample_run)
-
-#     info = {'my_info': [1, 2, 3], 'nr': 7}
-#     outp = 'some output'
-#     with tempfile.NamedTemporaryFile() as f:
-#         f.write(outp.encode())
-#         f.flush()
-#         tinydb_obs.heartbeat_event(info=info, cout_filename=f.name,
-#                                    beat_time=T2)
-
-#     assert len(tinydb_obs.runs) == 1
-#     db_run = tinydb_obs.runs.get(eid=1)
-#     assert db_run['heartbeat'] == T2
-#     assert db_run['info'] == info
-#     assert db_run['captured_out'] == outp
-
-
-# def test_tinydb_observer_completed_event_updates_run(tinydb_obs, sample_run):
-#     tinydb_obs.started_event(**sample_run)
-
-#     tinydb_obs.completed_event(stop_time=T2, result=42)
-
-#     assert len(tinydb_obs.runs) == 1
-#     db_run = tinydb_obs.runs.get(eid=1)
-#     assert db_run['stop_time'] == T2
-#     assert db_run['result'] == 42
-#     assert db_run['status'] == 'COMPLETED'
-
-
-# def test_tinydb_observer_interrupted_event_updates_run(tinydb_obs,
-#                                                        sample_run):
-#     tinydb_obs.started_event(**sample_run)
-
-#     tinydb_obs.interrupted_event(interrupt_time=T2, status='INTERRUPTED')
-
-#     assert len(tinydb_obs.runs) == 1
-#     db_run = tinydb_obs.runs.get(eid=1)
-#     assert db_run['stop_time'] == T2
-#     assert db_run['status'] == 'INTERRUPTED'
-
-
-# def test_tinydb_observer_failed_event_updates_run(tinydb_obs, sample_run):
-#     tinydb_obs.started_event(**sample_run)
-
-#     fail_trace = "lots of errors and\nso\non..."
-#     tinydb_obs.failed_event(fail_time=T2,
-#                             fail_trace=fail_trace)
-
-#     assert len(tinydb_obs.runs) == 1
-#     db_run = tinydb_obs.runs.get(eid=1)
-#     assert db_run['stop_time'] == T2
-#     assert db_run['status'] == 'FAILED'
-#     assert db_run['fail_trace'] == fail_trace
-
-
-# def test_tinydb_observer_artifact_event(tinydb_obs, sample_run):
-#     tinydb_obs.started_event(**sample_run)
-
-#     filename = "setup.py"
-#     name = 'mysetup'
-
-#     tinydb_obs.artifact_event(name, filename)
-
-#     assert tinydb_obs.fs.exists(filename)
-
-#     db_run = tinydb_obs.runs.get(eid=1)
-#     assert db_run['artifacts'][0][0] == name
-
-#     with open(filename, 'rb') as f:
-#         file_content = f.read()
-#     assert db_run['artifacts'][0][3].read() == file_content
-
-
-# def test_tinydb_observer_resource_event(tinydb_obs, sample_run):
-#     tinydb_obs.started_event(**sample_run)
-
-#     filename = "setup.py"
-#     md5 = get_digest(filename)
-
-#     tinydb_obs.resource_event(filename)
-
-#     assert tinydb_obs.fs.exists(filename)
-
-#     db_run = tinydb_obs.runs.get(eid=1)
-#     assert db_run['resources'][0][:2] == [filename, md5]
-
-#     with open(filename, 'rb') as f:
-#         file_content = f.read()
-#     assert db_run['resources'][0][2].read() == file_content
-
-
-# def test_tinydb_observer_resource_event_when_resource_present(tinydb_obs,
-#                                                               sample_run):
-#     tinydb_obs.started_event(**sample_run)
-
-#     filename = "setup.py"
-#     md5 = get_digest(filename)
-
-#     # Add file by other means
-#     tinydb_obs.fs.put(filename)
-
-#     tinydb_obs.resource_event(filename)
-
-#     db_run = tinydb_obs.runs.get(eid=1)
-#     assert db_run['resources'][0][:2] == [filename, md5]
-
-
-# @pytest.mark.skipif(not opt.has_numpy, reason='needs numpy')
-# def test_serialisation_of_numpy_ndarray(tmpdir):
-#     from sacred.observers.tinydb_hashfs import NdArraySerializer
-#     from tinydb_serialization import SerializationMiddleware
-#     import numpy as np
-
-#     # Setup Serialisation object for non list/dict objects
-#     serialization_store = SerializationMiddleware()
-#     serialization_store.register_serializer(NdArraySerializer(), 'TinyArray')
-
-#     db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'),
-#                 storage=serialization_store)
-
-#     eye_mat = np.eye(3)
-#     ones_array = np.ones(5)
-
-#     document = {
-#         'foo': 'bar',
-#         'some_array': eye_mat,
-#         'nested': {
-#             'ones': ones_array
-#         }
-#     }
-
-#     db.insert(document)
-#     returned_doc = db.all()[0]
-
-#     assert returned_doc['foo'] == 'bar'
-#     assert (returned_doc['some_array'] == eye_mat).all()
-#     assert (returned_doc['nested']['ones'] == ones_array).all()
-
-
-# @pytest.mark.skipif(not opt.has_pandas, reason='needs pandas')
-# def test_serialisation_of_pandas_dataframe(tmpdir):
-#     from sacred.observers.tinydb_hashfs import (DataFrameSerializer,
-#                                                 SeriesSerializer)
-#     from tinydb_serialization import SerializationMiddleware
-
-#     import numpy as np
-#     import pandas as pd
-
-#     # Setup Serialisation object for non list/dict objects
-#     serialization_store = SerializationMiddleware()
-#     serialization_store.register_serializer(DataFrameSerializer(),
-#                                             'TinyDataFrame')
-#     serialization_store.register_serializer(SeriesSerializer(),
-#                                             'TinySeries')
-
-#     db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'),
-#                 storage=serialization_store)
-
-#     df = pd.DataFrame(np.eye(3), columns=list('ABC'))
-#     series = pd.Series(np.ones(5))
-
-#     document = {
-#         'foo': 'bar',
-#         'some_dataframe': df,
-#         'nested': {
-#             'ones': series
-#         }
-#     }
-
-#     db.insert(document)
-#     returned_doc = db.all()[0]
-
-#     assert returned_doc['foo'] == 'bar'
-#     assert (returned_doc['some_dataframe'] == df).all().all()
-#     assert (returned_doc['nested']['ones'] == series).all()
-
-
-# def test_parse_tinydb_arg():
-#     assert TinyDbOption.parse_tinydb_arg('foo') == 'foo'
-
-
-# def test_parse_tinydboption_apply(tmpdir):
-
-#     exp = Experiment()
-#     args = os.path.join(tmpdir.strpath)
-
-#     TinyDbOption.apply(args, exp)
-#     assert type(exp.observers[0]) == TinyDbObserver
+def test_fetch_metadata_function_with_indices(tmpdir, sample_run):
+    
+    # Setup and run three experiments
+    root = tmpdir.strpath
+    tinydb_obs = run_test_experiment(exp_name='experiment 1 alpha', 
+                                     exp_id='1234', root_dir=root)
+    tinydb_obs = run_test_experiment(exp_name='experiment 2 beta', 
+                                     exp_id='5678', root_dir=root)
+    tinydb_obs = run_test_experiment(exp_name='experiment 3 alpha', 
+                                     exp_id='9990', root_dir=root)
+
+    tinydb_reader = TinyDbReader(root)
+
+    # Test fetch by indices 
+    res = tinydb_reader.fetch_metadata(indices=-1)
+    res2 = tinydb_reader.fetch_metadata(indices=[-1])
+    assert strip_file_handles(res) == strip_file_handles(res2)
+    res3 = tinydb_reader.fetch_metadata(indices=[0, -1])
+    assert len(res3) == 2
+
+    exp1_res = tinydb_reader.fetch_metadata(indices=0)
+    assert len(exp1_res) == 1
+    assert exp1_res[0]['experiment']['name'] == 'experiment 1 alpha'
+    assert exp1_res[0]['_id'] == '1234'
+
+    exp1 = strip_file_handles(exp1_res)[0]
+
+    sample_run['ex_info']['name'] = 'experiment 1 alpha'
+    sample_run['ex_info']['sources'] = [
+        ['setup.py', get_digest('setup.py')]
+    ]
+
+    assert exp1 == {
+        '_id': '1234',
+        'experiment': sample_run['ex_info'],
+        'format': tinydb_obs.VERSION,
+        'command': sample_run['command'],
+        'host': sample_run['host_info'],
+        'start_time': sample_run['start_time'],
+        'heartbeat': datetime.datetime(1999, 5, 5, 5, 5, 5, 5),
+        'info': {'my_info': [1, 2, 3], 'nr': 7},
+        'captured_out': 'some output',
+        'artifacts': [
+            ['about', 'sacred/__about__.py', get_digest('sacred/__about__.py')]
+        ],
+        'config': sample_run['config'],
+        'meta': sample_run['meta_info'],
+        'status': 'COMPLETED',
+        'resources': [
+            ['sacred/__init__.py', get_digest('sacred/__init__.py')]
+        ], 
+        'result': 42, 
+        'stop_time': datetime.datetime(1999, 5, 5, 6, 6, 6, 6)
+    }
+
+
+def test_fetch_metadata_function_with_exp_name(tmpdir):
+    
+    # Setup and run three experiments
+    root = tmpdir.strpath
+    tinydb_obs = run_test_experiment(exp_name='experiment 1 alpha', 
+                                     exp_id='1234', root_dir=root)
+    tinydb_obs = run_test_experiment(exp_name='experiment 2 beta', 
+                                     exp_id='5678', root_dir=root)
+    tinydb_obs = run_test_experiment(exp_name='experiment 3 alpha', 
+                                     exp_id='9990', root_dir=root)
+
+    tinydb_reader = TinyDbReader(root)
+
+    # Test Fetch by exp name
+    res1 = tinydb_reader.fetch_metadata(exp_name='alpha')
+    assert len(res1) == 2
+    res2 = tinydb_reader.fetch_metadata(exp_name='experiment 1')
+    assert len(res2) == 1
+    assert res2[0]['experiment']['name'] == 'experiment 1 alpha'
+    res2 = tinydb_reader.fetch_metadata(exp_name='foo')
+    assert len(res2) == 0
+    
+
+def test_fetch_metadata_function_with_querry(tmpdir):
+    
+    # Setup and run three experiments
+    root = tmpdir.strpath
+    tinydb_obs = run_test_experiment(exp_name='experiment 1 alpha', 
+                                     exp_id='1234', root_dir=root)
+    tinydb_obs = run_test_experiment(exp_name='experiment 2 beta', 
+                                     exp_id='5678', root_dir=root)
+    tinydb_obs = run_test_experiment(exp_name='experiment 3 alpha beta', 
+                                     exp_id='9990', root_dir=root)
+
+    tinydb_reader = TinyDbReader(root)
+
+    record = Query()
+
+    exp1_query = record.experiment.name.matches('.*alpha$')
+
+    exp3_query = (
+        (record.experiment.name.search('alpha')) & 
+        (record._id == '9990')
+    )
+
+    # Test Fetch by Tinydb Query
+    res1 = tinydb_reader.fetch_metadata(query=exp1_query)            
+    assert len(res1) == 1
+    assert res1[0]['experiment']['name'] == 'experiment 1 alpha'
+
+    res2 = tinydb_reader.fetch_metadata(
+        query=record.experiment.name.search('experiment [23]'))
+    assert len(res2) == 2
+
+    res3 = tinydb_reader.fetch_metadata(query=exp3_query)            
+    assert len(res3) == 1
+    assert res3[0]['experiment']['name'] == 'experiment 3 alpha beta'
+
+
+
+def test_search_function(tmpdir):
+    
+    # Setup and run three experiments
+    root = tmpdir.strpath
+    tinydb_obs = run_test_experiment(exp_name='experiment 1 alpha', 
+                                     exp_id='1234', root_dir=root)
+    tinydb_obs = run_test_experiment(exp_name='experiment 2 beta', 
+                                     exp_id='5678', root_dir=root)
+    tinydb_obs = run_test_experiment(exp_name='experiment 3 alpha beta', 
+                                     exp_id='9990', root_dir=root)
+
+    tinydb_reader = TinyDbReader(root)
+
+    # Test Fetch by Tinydb Query in search function
+    record = Query()
+    q = record.experiment.name.search('experiment [23]')
+
+    res = tinydb_reader.search(q)
+    assert len(res) == 2
+    res2 = tinydb_reader.fetch_metadata(query=q)
+    assert strip_file_handles(res) == strip_file_handles(res2)
+
+
+def test_fetch_files_function(tmpdir):
+    # Setup and run three experiments
+    root = tmpdir.strpath
+    tinydb_obs = run_test_experiment(exp_name='experiment 1 alpha', 
+                                     exp_id='1234', root_dir=root)
+    tinydb_obs = run_test_experiment(exp_name='experiment 2 beta', 
+                                     exp_id='5678', root_dir=root)
+    tinydb_obs = run_test_experiment(exp_name='experiment 3 alpha beta', 
+                                     exp_id='9990', root_dir=root)
+
+    tinydb_reader = TinyDbReader(root)
+
+    res = tinydb_reader.fetch_files(indices=0) 
+    assert len(res) == 1
+    assert list(res[0]['artifacts'].keys()) == ['about']
+    assert isinstance(res[0]['artifacts']['about'], io.BufferedReader)
+    assert res[0]['date'] == datetime.datetime(1999, 5, 4, 3, 2, 1)
+    assert res[0]['exp_id'] == '1234'
+    assert res[0]['exp_name'] == 'experiment 1 alpha'
+    assert list(res[0]['resources'].keys()) == ['sacred/__init__.py']
+    assert isinstance(res[0]['resources']['sacred/__init__.py'], io.BufferedReader)
+    assert list(res[0]['sources'].keys()) == ['setup.py']
+    assert isinstance(res[0]['sources']['setup.py'], io.BufferedReader)
+
+
+def test_fetch_report_function(tmpdir):
+    
+    # Setup and run three experiments
+    root = tmpdir.strpath
+    tinydb_obs = run_test_experiment(exp_name='experiment 1 alpha', 
+                                     exp_id='1234', root_dir=root)
+    tinydb_obs = run_test_experiment(exp_name='experiment 2 beta', 
+                                     exp_id='5678', root_dir=root)
+    tinydb_obs = run_test_experiment(exp_name='experiment 3 alpha beta', 
+                                     exp_id='9990', root_dir=root)
+
+    tinydb_reader = TinyDbReader(root)
+
+    res = tinydb_reader.fetch_report(indices=0)
+
+    target = """
+-------------------------------------------------
+Experiment: experiment 1 alpha
+-------------------------------------------------
+ID: 1234
+Date: Tue 04 May 1999    Duration: 27:04:05.0
+
+Parameters:
+    answer: 42
+    config: True
+    foo: bar
+
+Result:
+    42
+
+Dependencies:
+    sacred==0.7b0
+
+Resources:
+    sacred/__init__.py
+
+Source Files:
+    setup.py
+
+Outputs:
+    about
+"""
+
+    assert res[0] == target

--- a/tests/test_observers/test_tinydb_reader.py
+++ b/tests/test_observers/test_tinydb_reader.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python
+# coding=utf-8
+from __future__ import (division, print_function, unicode_literals,
+                        absolute_import)
+
+import os
+import datetime
+import tempfile
+import io
+
+import pytest
+
+from tinydb import TinyDB
+from hashfs import HashFS
+
+from sacred.dependencies import get_digest
+from sacred.observers.tinydb_hashfs import TinyDbObserver, TinyDbReader
+from sacred import optional as opt
+from sacred.experiment import Experiment
+
+T1 = datetime.datetime(1999, 5, 4, 3, 2, 1, 0)
+T2 = datetime.datetime(1999, 5, 5, 5, 5, 5, 5)
+
+
+@pytest.fixture()
+def sample_run():
+    exp = {'name': 'test_exp', 'sources': [], 'doc': '', 'base_dir': '/tmp'}
+    host = {'hostname': 'test_host', 'cpu_count': 1, 'python_version': '3.4'}
+    config = {'config': 'True', 'foo': 'bar', 'answer': 42}
+    command = 'run'
+    meta_info = {'comment': 'test run'}
+    return {
+        '_id': 'FEDCBA9876543210',
+        'ex_info': exp,
+        'command': command,
+        'host_info': host,
+        'start_time': T1,
+        'config': config,
+        'meta_info': meta_info,
+    }
+
+
+@pytest.fixture()
+def tinydb_obs(tmpdir, sample_run):
+    """TindDB Observer with example data"""
+
+    # Create
+    tinydb_obs = TinyDbObserver.create(path=tmpdir.strpath)
+
+    # Sample
+    _id = tinydb_obs.started_event(**sample_run)
+
+    # Heartbeat
+    info = {'my_info': [1, 2, 3], 'nr': 7}
+    outp = 'some output'
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(outp.encode())
+        f.flush()
+        tinydb_obs.heartbeat_event(info=info, cout_filename=f.name,
+                                   beat_time=T2)
+    # Add Artifact
+    filename = "setup.py"
+    name = 'mysetup'
+    tinydb_obs.artifact_event(name, filename)
+
+    # Add Resource
+    filename = "sacred/__init__.py"
+    tinydb_obs.resource_event(filename)
+
+    # Complete
+    tinydb_obs.completed_event(stop_time=T2, result=42)
+
+    return tinydb_obs
+
+
+@pytest.fixture()
+def tinydb_reader(tinydb_obs):
+    return TinyDbReader(tinydb_obs.root)
+
+
+def test_tinydb_reader_loads_db_and_fs(tinydb_obs, tinydb_reader):
+    assert tinydb_obs.fs.root == tinydb_reader.fs.root
+    assert str(tinydb_obs.runs.all()[0]) == str(tinydb_reader.runs.all()[0]) 
+
+
+def test_fetch_metadata_function():
+    pass
+
+
+def test_search_function():
+    pass
+
+
+def test_fetch_files_function():
+    pass
+
+
+def test_fetch_report_function():
+    pass
+
+
+
+
+
+#     sample_run['_id'] = None
+#     _id = tinydb_obs.started_event(**sample_run)
+#     assert _id is not None
+#     assert len(tinydb_obs.runs) == 1
+#     db_run = tinydb_obs.runs.get(eid=1)
+#     assert db_run == {
+#         '_id': _id,
+#         'experiment': sample_run['ex_info'],
+#         'format': tinydb_obs.VERSION,
+#         'command': sample_run['command'],
+#         'host': sample_run['host_info'],
+#         'start_time': sample_run['start_time'],
+#         'heartbeat': None,
+#         'info': {},
+#         'captured_out': '',
+#         'artifacts': [],
+#         'config': sample_run['config'],
+#         'meta': sample_run['meta_info'],
+#         'status': 'RUNNING',
+#         'resources': []
+#     }
+
+
+# def test_tindb_observer_started_event_saves_given_sources(tinydb_obs,
+#                                                           sample_run):
+
+#     filename = 'setup.py'
+#     md5 = get_digest(filename)
+
+#     sample_run['ex_info']['sources'] = [[filename, md5]]
+#     _id = tinydb_obs.started_event(**sample_run)
+
+#     assert _id is not None
+#     assert len(tinydb_obs.runs) == 1
+#     db_run = tinydb_obs.runs.get(eid=1)
+
+#     # Check all but the experiment section
+#     db_run_copy = db_run.copy()
+#     del db_run_copy['experiment']
+#     assert db_run_copy == {
+#         '_id': _id,
+#         'format': tinydb_obs.VERSION,
+#         'command': sample_run['command'],
+#         'host': sample_run['host_info'],
+#         'start_time': sample_run['start_time'],
+#         'heartbeat': None,
+#         'info': {},
+#         'captured_out': '',
+#         'artifacts': [],
+#         'config': sample_run['config'],
+#         'meta': sample_run['meta_info'],
+#         'status': 'RUNNING',
+#         'resources': []
+#     }
+
+#     assert len(db_run['experiment']['sources']) == 1
+#     assert len(db_run['experiment']['sources'][0]) == 3
+#     assert db_run['experiment']['sources'][0][:2] == [filename, md5]
+#     assert isinstance(db_run['experiment']['sources'][0][2], io.BufferedReader)
+
+#     # Check that duplicate source files are still listed in ex_info
+#     tinydb_obs.db_run_id = None
+#     tinydb_obs.started_event(**sample_run)
+#     assert len(tinydb_obs.runs) == 2
+#     db_run2 = tinydb_obs.runs.get(eid=2)
+
+#     assert db_run['experiment']['sources'][0][:2] == db_run2['experiment']['sources'][0][:2]
+
+
+# def test_tindb_observer_started_event_generates_different_run_ids(tinydb_obs,
+#                                                                   sample_run):
+#     sample_run['_id'] = None
+#     _id = tinydb_obs.started_event(**sample_run)
+#     assert _id is not None
+
+#     # Check that duplicate source files are still listed in ex_info
+#     tinydb_obs.db_run_id = None
+#     sample_run['_id'] = None
+#     _id2 = tinydb_obs.started_event(**sample_run)
+
+#     assert len(tinydb_obs.runs) == 2
+#     # Check new random id is given for each run
+#     assert _id != _id2
+
+
+# def test_tinydb_observer_queued_event_is_not_implimented(tinydb_obs,
+#                                                          sample_run):
+
+#     sample_queued_run = sample_run.copy()
+#     del sample_queued_run['host_info']
+#     del sample_queued_run['start_time']
+#     sample_queued_run['queue_time'] = T1
+
+#     with pytest.raises(NotImplementedError):
+#         tinydb_obs.queued_event(**sample_queued_run)
+
+
+# def test_tinydb_observer_equality(tmpdir, tinydb_obs):
+
+#     db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'))
+#     fs = HashFS(os.path.join(tmpdir.strpath, 'hashfs'), depth=3,
+#                 width=2, algorithm='md5')
+#     m = TinyDbObserver(db, fs)
+
+#     assert tinydb_obs == m
+#     assert not tinydb_obs != m
+
+#     assert not tinydb_obs == 'foo'
+#     assert tinydb_obs != 'foo'
+
+
+# def test_tinydb_observer_heartbeat_event_updates_run(tinydb_obs, sample_run):
+#     tinydb_obs.started_event(**sample_run)
+
+#     info = {'my_info': [1, 2, 3], 'nr': 7}
+#     outp = 'some output'
+#     with tempfile.NamedTemporaryFile() as f:
+#         f.write(outp.encode())
+#         f.flush()
+#         tinydb_obs.heartbeat_event(info=info, cout_filename=f.name,
+#                                    beat_time=T2)
+
+#     assert len(tinydb_obs.runs) == 1
+#     db_run = tinydb_obs.runs.get(eid=1)
+#     assert db_run['heartbeat'] == T2
+#     assert db_run['info'] == info
+#     assert db_run['captured_out'] == outp
+
+
+# def test_tinydb_observer_completed_event_updates_run(tinydb_obs, sample_run):
+#     tinydb_obs.started_event(**sample_run)
+
+#     tinydb_obs.completed_event(stop_time=T2, result=42)
+
+#     assert len(tinydb_obs.runs) == 1
+#     db_run = tinydb_obs.runs.get(eid=1)
+#     assert db_run['stop_time'] == T2
+#     assert db_run['result'] == 42
+#     assert db_run['status'] == 'COMPLETED'
+
+
+# def test_tinydb_observer_interrupted_event_updates_run(tinydb_obs,
+#                                                        sample_run):
+#     tinydb_obs.started_event(**sample_run)
+
+#     tinydb_obs.interrupted_event(interrupt_time=T2, status='INTERRUPTED')
+
+#     assert len(tinydb_obs.runs) == 1
+#     db_run = tinydb_obs.runs.get(eid=1)
+#     assert db_run['stop_time'] == T2
+#     assert db_run['status'] == 'INTERRUPTED'
+
+
+# def test_tinydb_observer_failed_event_updates_run(tinydb_obs, sample_run):
+#     tinydb_obs.started_event(**sample_run)
+
+#     fail_trace = "lots of errors and\nso\non..."
+#     tinydb_obs.failed_event(fail_time=T2,
+#                             fail_trace=fail_trace)
+
+#     assert len(tinydb_obs.runs) == 1
+#     db_run = tinydb_obs.runs.get(eid=1)
+#     assert db_run['stop_time'] == T2
+#     assert db_run['status'] == 'FAILED'
+#     assert db_run['fail_trace'] == fail_trace
+
+
+# def test_tinydb_observer_artifact_event(tinydb_obs, sample_run):
+#     tinydb_obs.started_event(**sample_run)
+
+#     filename = "setup.py"
+#     name = 'mysetup'
+
+#     tinydb_obs.artifact_event(name, filename)
+
+#     assert tinydb_obs.fs.exists(filename)
+
+#     db_run = tinydb_obs.runs.get(eid=1)
+#     assert db_run['artifacts'][0][0] == name
+
+#     with open(filename, 'rb') as f:
+#         file_content = f.read()
+#     assert db_run['artifacts'][0][3].read() == file_content
+
+
+# def test_tinydb_observer_resource_event(tinydb_obs, sample_run):
+#     tinydb_obs.started_event(**sample_run)
+
+#     filename = "setup.py"
+#     md5 = get_digest(filename)
+
+#     tinydb_obs.resource_event(filename)
+
+#     assert tinydb_obs.fs.exists(filename)
+
+#     db_run = tinydb_obs.runs.get(eid=1)
+#     assert db_run['resources'][0][:2] == [filename, md5]
+
+#     with open(filename, 'rb') as f:
+#         file_content = f.read()
+#     assert db_run['resources'][0][2].read() == file_content
+
+
+# def test_tinydb_observer_resource_event_when_resource_present(tinydb_obs,
+#                                                               sample_run):
+#     tinydb_obs.started_event(**sample_run)
+
+#     filename = "setup.py"
+#     md5 = get_digest(filename)
+
+#     # Add file by other means
+#     tinydb_obs.fs.put(filename)
+
+#     tinydb_obs.resource_event(filename)
+
+#     db_run = tinydb_obs.runs.get(eid=1)
+#     assert db_run['resources'][0][:2] == [filename, md5]
+
+
+# @pytest.mark.skipif(not opt.has_numpy, reason='needs numpy')
+# def test_serialisation_of_numpy_ndarray(tmpdir):
+#     from sacred.observers.tinydb_hashfs import NdArraySerializer
+#     from tinydb_serialization import SerializationMiddleware
+#     import numpy as np
+
+#     # Setup Serialisation object for non list/dict objects
+#     serialization_store = SerializationMiddleware()
+#     serialization_store.register_serializer(NdArraySerializer(), 'TinyArray')
+
+#     db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'),
+#                 storage=serialization_store)
+
+#     eye_mat = np.eye(3)
+#     ones_array = np.ones(5)
+
+#     document = {
+#         'foo': 'bar',
+#         'some_array': eye_mat,
+#         'nested': {
+#             'ones': ones_array
+#         }
+#     }
+
+#     db.insert(document)
+#     returned_doc = db.all()[0]
+
+#     assert returned_doc['foo'] == 'bar'
+#     assert (returned_doc['some_array'] == eye_mat).all()
+#     assert (returned_doc['nested']['ones'] == ones_array).all()
+
+
+# @pytest.mark.skipif(not opt.has_pandas, reason='needs pandas')
+# def test_serialisation_of_pandas_dataframe(tmpdir):
+#     from sacred.observers.tinydb_hashfs import (DataFrameSerializer,
+#                                                 SeriesSerializer)
+#     from tinydb_serialization import SerializationMiddleware
+
+#     import numpy as np
+#     import pandas as pd
+
+#     # Setup Serialisation object for non list/dict objects
+#     serialization_store = SerializationMiddleware()
+#     serialization_store.register_serializer(DataFrameSerializer(),
+#                                             'TinyDataFrame')
+#     serialization_store.register_serializer(SeriesSerializer(),
+#                                             'TinySeries')
+
+#     db = TinyDB(os.path.join(tmpdir.strpath, 'metadata.json'),
+#                 storage=serialization_store)
+
+#     df = pd.DataFrame(np.eye(3), columns=list('ABC'))
+#     series = pd.Series(np.ones(5))
+
+#     document = {
+#         'foo': 'bar',
+#         'some_dataframe': df,
+#         'nested': {
+#             'ones': series
+#         }
+#     }
+
+#     db.insert(document)
+#     returned_doc = db.all()[0]
+
+#     assert returned_doc['foo'] == 'bar'
+#     assert (returned_doc['some_dataframe'] == df).all().all()
+#     assert (returned_doc['nested']['ones'] == series).all()
+
+
+# def test_parse_tinydb_arg():
+#     assert TinyDbOption.parse_tinydb_arg('foo') == 'foo'
+
+
+# def test_parse_tinydboption_apply(tmpdir):
+
+#     exp = Experiment()
+#     args = os.path.join(tmpdir.strpath)
+
+#     TinyDbOption.apply(args, exp)
+#     assert type(exp.observers[0]) == TinyDbObserver

--- a/tests/test_observers/test_tinydb_reader.py
+++ b/tests/test_observers/test_tinydb_reader.py
@@ -62,7 +62,7 @@ def run_test_experiment(exp_name, exp_id, root_dir):
     tinydb_obs = TinyDbObserver.create(path=root_dir)
 
     # Start exp 1
-    _id = tinydb_obs.started_event(**run_date)
+    tinydb_obs.started_event(**run_date)
 
     # Heartbeat
     info = {'my_info': [1, 2, 3], 'nr': 7}
@@ -71,7 +71,7 @@ def run_test_experiment(exp_name, exp_id, root_dir):
         f.write(outp.encode())
         f.flush()
         tinydb_obs.heartbeat_event(info=info, cout_filename=f.name,
-                                    beat_time=T2)
+                                   beat_time=T2)
     # Add Artifact
     filename = "sacred/__about__.py"
     name = 'about'

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,9 @@ deps =
     wrapt
     mongomock
     pymongo
+    tinydb
+    tinydb-serialization
+    hashfs
 commands =
     py.test \
         {posargs} # substitute with tox' positional arguments
@@ -35,6 +38,9 @@ deps =
     pep8-naming
     mccabe
     flake8-docstrings
+    tinydb
+    tinydb-serialization
+    hashfs
 commands =
     flake8 --max-complexity 10 sacred
 
@@ -56,6 +62,9 @@ deps =
     coveralls
     sqlalchemy
     pandas
+    tinydb
+    tinydb-serialization
+    hashfs
 
 commands =
     py.test \


### PR DESCRIPTION
As per #121 , this is the implementation of a TinyDBObserver that uses tinydb for metadata and hashfs for the local file system. 

* Tests written and all run locally on Mac OS for py27, py33, py34 and py35.  

Outstanding test failures / tasks are as follows:

- [ ]  File permission error in appveyor when attempting to read a file from a temporary directory.  
- [x]  Errors in running coverage
- [x]  Add command line option for using tinydb observer
- [x]  Add file retrieval method for convinience. 
- [x]  Documentation needs updating
