### PR TITLE
Pretty docstring printing

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,9 +6,9 @@ from __future__ import division, print_function, unicode_literals
 import pprint
 
 import pytest
-from sacred.commands import (BLUE, ENDC, GREEN, RED, ConfigEntry, PathEntry,
-                             _format_config, _format_entry, help_for_command,
-                             _iterate_marked, _non_unicode_repr)
+from sacred.commands import (BLUE, ENDC, GREY, GREEN, RED, ConfigEntry,
+                             PathEntry, _format_config, _format_entry,
+                             help_for_command, _iterate_marked, _non_unicode_repr)
 from sacred.config.config_summary import ConfigSummary
 
 
@@ -107,6 +107,9 @@ def test_iterate_marked_typechanged(cfg):
     (ConfigEntry('e', {}, False, False, None, None),      "e = {}"),
     # Path entries
     (PathEntry('f', False, False, None, None), "f:"),
+    # Docstring entry
+    (ConfigEntry('__doc__', 'multiline\ndocstring', False, False, None, None),
+     GREY + '"""multiline\ndocstring"""' + ENDC),
 ])
 def test_format_entry(entry, expected):
     assert _format_entry(0, entry) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,13 +25,13 @@ def test_recursive_update():
 
 def test_iterate_flattened_separately():
     d = {'a1': 1,
-         'b2': {'foo': 'bar'},
+         'b2': {'bar': 'foo', 'foo': 'bar'},
          'c1': 'f',
          'd1': [1, 2, 3],
          'e2': {}}
-    res = list(iterate_flattened_separately(d))
+    res = list(iterate_flattened_separately(d, ['foo', 'bar']))
     assert res == [('a1', 1), ('c1', 'f'), ('d1', [1, 2, 3]), ('e2', {}),
-                   ('b2', PATHCHANGE), ('b2.foo', 'bar')]
+                   ('b2', PATHCHANGE), ('b2.foo', 'bar'), ('b2.bar', 'foo')]
 
 
 def test_iterate_flattened():


### PR DESCRIPTION
This PR resolves the feature issue #123 . I modified the _iterate_flattened_separately_ utility function to enable looping over a manually sorted dictionary. This allows me to print the _docstring_ at first in every configuration child dictionary.
The prettified doc printing is implemented in the __format_entry_ function where the _docstring_ is handled individually. As suggested I used grey for the colored output which is also part of the legend now. Also the configuration entry specific documentation is now printed grey.