### PR TITLE
Explicitly blacklist __main__ module for python3 compatibility

### DIFF
--- a/sacred/commands.py
+++ b/sacred/commands.py
@@ -37,6 +37,7 @@ def _non_unicode_repr(objekt, context, maxlevels, level):
         repr_string = repr_string[1:]
     return repr_string, isreadable, isrecursive
 
+
 PRINTER = pprint.PrettyPrinter()
 PRINTER.format = _non_unicode_repr
 

--- a/sacred/config/config_files.py
+++ b/sacred/config/config_files.py
@@ -17,6 +17,7 @@ class Handler(object):
         self.dump = dump
         self.mode = mode
 
+
 HANDLER_BY_EXT = {
     '.json': Handler(json.load, json.dump, ''),
     '.pickle': Handler(pickle.load, pickle.dump, 'b'),

--- a/sacred/dependencies.py
+++ b/sacred/dependencies.py
@@ -16,7 +16,7 @@ from sacred.utils import is_subdir, iter_prefixes
 __sacred__ = True  # marks files that should be filtered from stack traces
 
 MB = 1048576
-MODULE_BLACKLIST = {None, '__future__', 'hashlib', 'os', 're'} | \
+MODULE_BLACKLIST = {None, '__future__', '__main__', 'hashlib', 'os', 're'} | \
     set(sys.builtin_module_names)
 module = type(sys)
 PEP440_VERSION_PATTERN = re.compile(r"""

--- a/sacred/optional.py
+++ b/sacred/optional.py
@@ -24,6 +24,7 @@ def optional_import(package_name):
     except ImportError:
         return False, None
 
+
 has_pymongo, pymongo = optional_import('pymongo')
 has_numpy, np = optional_import('numpy')
 has_yaml, yaml = optional_import('yaml')


### PR DESCRIPTION
I ran into an issue (traceback at the bottom) when trying to run `examples/ingredient.py`. In`python3` `__main__` is no longer in `sys.builtin_module_names`.

With this change I'm able to run `examples/ingredient.py` successfully with `python3`.

Also fixes 3 flake8 errors to make tox pass.

```
$python examples/ingredient.py
Traceback (most recent call last):
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/_vendor/packaging/requirements.py", line 90, in __init__
    req = REQUIREMENT.parseString(requirement_string)
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/_vendor/pyparsing.py", line 1617, in parseString
    raise exc
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/_vendor/pyparsing.py", line 1607, in parseString
    loc, tokens = self._parse( instring, 0 )
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/_vendor/pyparsing.py", line 1379, in _parseNoCache
    loc,tokens = self.parseImpl( instring, preloc, doActions )
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/_vendor/pyparsing.py", line 3376, in parseImpl
    loc, exprtokens = e._parse( instring, loc, doActions )
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/_vendor/pyparsing.py", line 1379, in _parseNoCache
    loc,tokens = self.parseImpl( instring, preloc, doActions )
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/_vendor/pyparsing.py", line 3698, in parseImpl
    return self.expr._parse( instring, loc, doActions, callPreParse=False )
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/_vendor/pyparsing.py", line 1379, in _parseNoCache
    loc,tokens = self.parseImpl( instring, preloc, doActions )
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/_vendor/pyparsing.py", line 3359, in parseImpl
    loc, resultlist = self.exprs[0]._parse( instring, loc, doActions, callPreParse=False )
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/_vendor/pyparsing.py", line 1383, in _parseNoCache
    loc,tokens = self.parseImpl( instring, preloc, doActions )
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/_vendor/pyparsing.py", line 2670, in parseImpl
    raise ParseException(instring, loc, self.errmsg, self)
pkg_resources._vendor.pyparsing.ParseException: Expected W:(abcd...) (at char 0), (line:1, col:1)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2873, in __init__
    super(Requirement, self).__init__(requirement_string)
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/_vendor/packaging/requirements.py", line 94, in __init__
    requirement_string[e.loc:e.loc + 8]))
pkg_resources.extern.packaging.requirements.InvalidRequirement: Invalid requirement, parse error at "'__main__'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "examples/ingredient.py", line 45, in <module>
    @ex.automain
  File "/data2/dev/sacred/sacred/experiment.py", line 109, in automain
    self.run_commandline()
  File "/data2/dev/sacred/sacred/experiment.py", line 203, in run_commandline
    args)
  File "/data2/dev/sacred/sacred/experiment.py", line 163, in run_command
    named_configs, force=force)
  File "/data2/dev/sacred/sacred/ingredient.py", line 310, in _create_run_for_command
    named_configs=named_configs, force=force)
  File "/data2/dev/sacred/sacred/initialize.py", line 316, in create_run
    experiment_info = experiment.get_experiment_info()
  File "/data2/dev/sacred/sacred/ingredient.py", line 286, in get_experiment_info
    dep.fill_missing_version()
  File "/data2/dev/sacred/sacred/dependencies.py", line 98, in fill_missing_version
    self.version = pkg_resources.get_distribution(self.name).version
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/__init__.py", line 551, in get_distribution
    dist = Requirement.parse(dist)
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2918, in parse
    req, = parse_requirements(s)
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2866, in parse_requirements
    yield Requirement(line)
  File "/home/lulu/envs/ambi/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2875, in __init__
    raise RequirementParseError(str(e))
pkg_resources.RequirementParseError: Invalid requirement, parse error at "'__main__'"
```