### PR TITLE
Changed default artifact name to filename instead of relative path

### DIFF
--- a/sacred/run.py
+++ b/sacred/run.py
@@ -154,7 +154,7 @@ class Run(object):
             Defaults to the relative file-path.
         """
         filename = os.path.abspath(filename)
-        name = os.path.relpath(filename) if name is None else name
+        name = os.path.basename(filename) if name is None else name
         self._emit_artifact_added(name, filename)
 
     def __call__(self, *args):

--- a/sacred/run.py
+++ b/sacred/run.py
@@ -151,7 +151,7 @@ class Run(object):
             name of the file to be stored as artifact
         name : str, optional
             optionally set the name of the artifact.
-            Defaults to the relative file-path.
+            Defaults to the filename.
         """
         filename = os.path.abspath(filename)
         name = os.path.basename(filename) if name is None else name


### PR DESCRIPTION
The [documentation](http://sacred.readthedocs.io/en/latest/collected_information.html#artifacts) states: *Artifacts are stored with a name, which (if it isn’t explicitly specified) defaults to the filename.* Currently this is not the case, as the default name is set to the relative path. This is a problem when using the FileStorageObserver because the relative path normally doesn't exists in the output folder.