### PR TITLE
fix exception in mongo.py on _id lookup

### DIFF
--- a/sacred/observers/mongo.py
+++ b/sacred/observers/mongo.py
@@ -181,7 +181,7 @@ class MongoObserver(RunObserver):
         if self.overwrite:
             return self.save()
 
-        autoinc_key = self.run_entry['_id'] is None
+        autoinc_key = self.run_entry.get('_id') is None
         while True:
             if autoinc_key:
                 c = self.runs.find({}, {'_id': 1})


### PR DESCRIPTION
mongo.py's insert method was attempting to check for the presence of the _id key by comparing dict['_id'] to None. This raised a KeyError, however. dict.get('_id') is the correct way to perform the check.