### PR TITLE
[WIP] Make source and dependencies potential repositories

### DIFF
--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -295,7 +295,7 @@ class Ingredient(object):
             base_dir=self.base_dir,
             sources=[s.to_json(self.base_dir) for s in sorted(sources)],
             dependencies=[d.to_json() for d in sorted(dependencies)],
-            repositories=collect_repositories(sources)
+            repositories=collect_repositories(sources | dependencies)
         )
 
     def traverse_ingredients(self):


### PR DESCRIPTION
### Why:

When running experiments, the source (core) code is often (should always be) under a version control software. However some dependencies can also be under development and thus should also be registered as repositories by sacred. If the user gives the argument --enforce-clean, it does not make sense not to check for dirty dependencies as well.

### How:

Factor out repository related stuff from Source and make both Source and PackageDependency inherit from Repository.

Ingredient.get_experiment_info()["repositories"] will now combine repositories from both sources and dependencies. Should we keep them separated?

NOTE: Repositories can only be considered equal if they share the same commit and are both clean. We cannot easily infer equality if they are dirty. EDIT: That's not enough because they can have a different history. We could compare history but it's starting to be tedious for what it's worth. Note that comparison of repositories is important in order to be able to keep a list of unique repos in experiment_info, otherwise it can get cluttered quite a lot.

### Questions:
1. Should we keep source and dependency repositories separated? It seams to me that it should be easy to distinguish them for the user, or it can be easily inferred based on the lists of sources and dependencies.
2. Current tests are lacking unit-tests regarding repository-related information extracted with git-python (Please tell me if I'm wrong). Did you avoid such tests because git-python is optional? I'd prefer to add tests though, would you have a preferred way of handling unit-tests with optional dependency? Personally, I would  simply do ```try: import git; except ImportError: git = None``` and skip tests if ```git is None```.

### To do:
- [ ] unit-tests (needs gitpython)
- [ ] update documentation (waiting for feedback before writing it)