### PR TITLE
Allow captured functions to be called normal code

### DIFF
--- a/sacred/config/captured_function.py
+++ b/sacred/config/captured_function.py
@@ -41,13 +41,15 @@ def captured_function(wrapped, instance, args, kwargs):
     bound = (instance is not None)
     args, kwargs = wrapped.signature.construct_arguments(args, kwargs, options,
                                                          bound)
-    wrapped.logger.debug("Started")
-    start_time = time.time()
+    if wrapped.logger is not None:
+        wrapped.logger.debug("Started")
+        start_time = time.time()
     # =================== run actual function =================================
     result = wrapped(*args, **kwargs)
     # =========================================================================
-    stop_time = time.time()
-    elapsed_time = timedelta(seconds=round(stop_time - start_time))
-    wrapped.logger.debug("Finished after %s.", elapsed_time)
+    if wrapped.logger is not None:
+        stop_time = time.time()
+        elapsed_time = timedelta(seconds=round(stop_time - start_time))
+        wrapped.logger.debug("Finished after %s.", elapsed_time)
 
     return result


### PR DESCRIPTION
This change enables non-experiment code to call captured functions.
When loading the configuration of a runned experiment this is
useful:

```python
from my_experiment import load_model
config = load_config()

model = load_model(**config)  # creates model with saved config

# continue loading weights or analysis the model
```

See issue #221 for a more detailed explanation. 