### PR TITLE
Improve TelegramObserver

### DIFF
--- a/docs/observers.rst
+++ b/docs/observers.rst
@@ -669,9 +669,18 @@ or pickle file containing...
   * ``token``: the HTTP API token acquired while
   * ``chat_id``: the ID (not username) of the chat to write the updates to.
     This can be a user or a group chat ID
-  * optionally: a boolean for ``silent_completion``. If set to true, regular experiment completions
+
+Additionally, a handful of optional arguments can be given in the config file:
+  * ``silent_success``: bool. If set to true, regular experiment completions
     will use no or less intrusive notifications, depending on the receiving device's platform.
     Experiment starts will always be sent silently, interruptions and failures always with full notifications.
+  * ``use_reply``: bool. If True, completion, interruption and failure messages will be sent as replies to the start message.
+  * ``send_image``: bool. If True, and if ``PIL.Image`` is available, experiment results that are deemed to be images by
+    ``Image.isImageType(result)`` will be sent as images with the ``completed_text_image`` as a caption.
+  * ``completed_text``: str. Format string to use upon completion.
+  * ``completed_text_image``: str. Format string for completion when the result is an image. Markdown will *not* work here!
+  * ``interrupted_text``: str. Format string for interruption message.
+  * ``failed_text``: str. Format string for failure message.
 
 The observer is then added to the experment like this:
 

--- a/sacred/observers/telegram_obs.py
+++ b/sacred/observers/telegram_obs.py
@@ -5,6 +5,14 @@ from __future__ import division, print_function, unicode_literals
 from sacred.observers.base import RunObserver
 from sacred.config.config_files import load_config_file
 import logging
+import os
+
+try:
+    from PIL import Image
+    import tempfile
+    HAVE_PIL = True
+except ImportError:
+    HAVE_PIL = False
 
 
 DEFAULT_TELEGRAM_PRIORITY = 10
@@ -47,9 +55,24 @@ class TelegramObserver(RunObserver):
 
         The file can be in any format supported by Sacred
         (.json, .pickle, [.yaml]).
-        It has to specify a ``token`` and a ``chat_id`` and can optionally set
-        ``silent_completion``,``completed_text``, ``interrupted_text``, and
-        ``failed_text``.
+        It has to specify a ``token`` and a ``chat_id`` (both strings) and can
+        optionally set these values:
+
+        * ``silent_success``: bool. If True, send a "silent" message upon
+          successful completion.
+        * ``completed_text``: str. Format string to use upon completion.
+        * ``use_reply``: bool. If True, completion, interruption and failure
+          messages will be sent as replies to the
+          start message.
+        * ``send_image``: bool. If True, and if ``PIL.Image`` is available,
+          experiment results that are deemed to be images by
+          ``Image.isImageType(result)`` will be sent as images with
+          the ``completed_text_image`` as a caption.
+        * ``completed_text_image``: str. Format string for completion when the
+          result is an image. Markdown will *not* work here!
+        * ``interrupted_text``: str. Format string for interruption message.
+        * ``failed_text``: str. Format string for failure message.
+
         """
         import telegram
         d = load_config_file(filename)
@@ -60,20 +83,26 @@ class TelegramObserver(RunObserver):
         else:
             raise ValueError("Telegram configuration file must contain "
                              "entries for 'token' and 'chat_id'!")
-        for k in ['completed_text', 'interrupted_text', 'failed_text']:
+        for k in ['started_text',
+                  'completed_text', 'completed_text_image',
+                  'interrupted_text', 'failed_text',
+                  'use_reply', 'send_image']:
             if k in d:
                 setattr(obs, k, d[k])
         return obs
 
-    def __init__(self, bot, chat_id, silent_completion=False,
+    def __init__(self, bot, chat_id, silent_success=False,
+                 use_reply=True, send_image=True,
                  priority=DEFAULT_TELEGRAM_PRIORITY, **kwargs):
-        self.silent_completion = silent_completion
+        self.silent_success = silent_success
         self.chat_id = chat_id
         self.bot = bot
 
         self.started_text = "♻ *{experiment[name]}* " \
                             "started at _{start_time}_ " \
                             "on host `{host_info[hostname]}`"
+        self.completed_text_image = "✅ {experiment[name]} " \
+                                    "completed after {elapsed_time}"
         self.completed_text = "✅ *{experiment[name]}* " \
                               "completed after _{elapsed_time}_ " \
                               "with result=`{result}`"
@@ -84,6 +113,9 @@ class TelegramObserver(RunObserver):
                            "Backtrace:\n```{backtrace}```"
         self.run = None
         self.priority = priority
+        self.start_message = None
+        self.use_reply = use_reply
+        self.send_image = send_image
 
     def started_event(self, ex_info, command, host_info, start_time, config,
                       meta_info, _id):
@@ -99,10 +131,11 @@ class TelegramObserver(RunObserver):
         if self.started_text is None:
             return
         try:
-            self.bot.send_message(chat_id=self.chat_id,
-                                  text=self.get_started_text(),
-                                  disable_notification=True,
-                                  parse_mode=telegram.ParseMode.MARKDOWN)
+            self.start_message = \
+                self.bot.send_message(chat_id=self.chat_id,
+                                      text=self.get_started_text(),
+                                      disable_notification=True,
+                                      parse_mode=telegram.ParseMode.MARKDOWN)
         except Exception as e:
             log = logging.getLogger('telegram-observer')
             log.warning('failed to send start_event message via telegram.',
@@ -111,7 +144,9 @@ class TelegramObserver(RunObserver):
     def get_started_text(self):
         return self.started_text.format(**self.run)
 
-    def get_completed_text(self):
+    def get_completed_text(self, image=False):
+        if image:
+            return self.completed_text_image.format(**self.run)
         return self.completed_text.format(**self.run)
 
     def get_interrupted_text(self):
@@ -132,11 +167,27 @@ class TelegramObserver(RunObserver):
         self.run['elapsed_time'] = td_format(stop_time -
                                              self.run['start_time'])
 
+        if self.use_reply and self.start_message:
+            reply_id = self.start_message.message_id
+        else:
+            reply_id = None
         try:
-            self.bot.send_message(chat_id=self.chat_id,
-                                  text=self.get_completed_text(),
-                                  disable_notification=self.silent_completion,
-                                  parse_mode=telegram.ParseMode.MARKDOWN)
+            if HAVE_PIL and self.send_image and Image.isImageType(result):
+                fh, fn = tempfile.mkstemp(suffix='.png')
+                result.save(fn)
+                os.close(fh)
+
+                with open(fn, 'rb') as f:
+                    self.bot.send_photo(self.chat_id, f, timeout=5,
+                                        reply_to_message_id=reply_id,
+                                        caption=self.get_completed_text(True))
+                os.remove(fn)
+            else:
+                self.bot.send_message(chat_id=self.chat_id,
+                                      text=self.get_completed_text(),
+                                      reply_to_message_id=reply_id,
+                                      disable_notification=self.silent_success,
+                                      parse_mode=telegram.ParseMode.MARKDOWN)
         except Exception as e:
             log = logging.getLogger('telegram-observer')
             log.warning('failed to send completed_event message via telegram.',
@@ -153,9 +204,14 @@ class TelegramObserver(RunObserver):
         self.run['elapsed_time'] = td_format(interrupt_time -
                                              self.run['start_time'])
 
+        if self.use_reply and self.start_message:
+            reply_id = self.start_message.message_id
+        else:
+            reply_id = None
         try:
             self.bot.send_message(chat_id=self.chat_id,
                                   text=self.get_interrupted_text(),
+                                  reply_to_message_id=reply_id,
                                   disable_notification=False,
                                   parse_mode=telegram.ParseMode.MARKDOWN)
         except Exception as e:
@@ -175,9 +231,14 @@ class TelegramObserver(RunObserver):
         self.run['elapsed_time'] = td_format(fail_time -
                                              self.run['start_time'])
 
+        if self.use_reply and self.start_message:
+            reply_id = self.start_message.message_id
+        else:
+            reply_id = None
         try:
             self.bot.send_message(chat_id=self.chat_id,
                                   text=self.get_failed_text(),
+                                  reply_to_message_id=reply_id,
                                   disable_notification=False,
                                   parse_mode=telegram.ParseMode.MARKDOWN)
         except Exception as e:


### PR DESCRIPTION
Send completions as replies, and send image results as image attachments with caption.

Not sure if this is wanted by anyone but me. I like it. For many of my experiments, the ultimate result is an image I want to visually inspect.