### PR TITLE
create_scaffolding silently pass non unique ingredient pathes

### DIFF
--- a/sacred/initialize.py
+++ b/sacred/initialize.py
@@ -240,8 +240,18 @@ def create_scaffolding(experiment, sorted_ingredients):
         named_configs=experiment.named_configs,
         config_hooks=experiment.config_hooks,
         generate_seed=True)
-    return OrderedDict([(sc.path, sc) for sc in scaffolding.values()])
+    
+    scaffolding_ret = OrderedDict([
+        (sc.path, sc)
+        for sc in scaffolding.values()
+    ])
+    if len(scaffolding_ret) != len(scaffolding):
+        raise ValueError(
+            'The pathes of the ingredients are not unique. '
+            '{}'.format([s.path for s in scaffolding])
+        )
 
+    return scaffolding_ret
 
 def gather_ingredients_topological(ingredient):
     sub_ingredients = defaultdict(int)

--- a/sacred/initialize.py
+++ b/sacred/initialize.py
@@ -240,7 +240,7 @@ def create_scaffolding(experiment, sorted_ingredients):
         named_configs=experiment.named_configs,
         config_hooks=experiment.config_hooks,
         generate_seed=True)
-    
+
     scaffolding_ret = OrderedDict([
         (sc.path, sc)
         for sc in scaffolding.values()
@@ -252,6 +252,7 @@ def create_scaffolding(experiment, sorted_ingredients):
         )
 
     return scaffolding_ret
+
 
 def gather_ingredients_topological(ingredient):
     sub_ingredients = defaultdict(int)


### PR DESCRIPTION
create_scaffolding uses `OrderedDict([(sc.path, sc) for sc in scaffolding.values()])`.
This code silently passes the case when the sc.path is not unique.
This PR raise, in that case, an error.

Here a minimal example that demonstrates the error:
```python
from sacred import Experiment, Ingredient
from sacred.commands import print_config

ing1 = Ingredient('ing1')
ing2 = Ingredient('ing1')  # <----------------------

ex = Experiment('my_experiment', ingredients=[ing1, ing2])

@ing1.config
def cfg():
    ing1 = 'ing1'  # <----------------- Not part of the config

@ing2.config
def cfg():
    ing2 = 'ing2'

@ex.config
def cfg():
    ex = 'ex'

@ex.automain
def run(_config, _run):
    print_config(_run)
```
and the output
```
$ python sacred_ingredient.py 
WARNING - my_experiment - No observers have been added to this run
INFO - my_experiment - Running command 'run'
INFO - my_experiment - Started
Configuration (modified, added, typechanged, doc):
  ex = 'ex'
  seed = 409741346                   # the random seed for this experiment
  ing1:
    ing2 = 'ing2'
INFO - my_experiment - Completed after 0:00:00
```