### PR TITLE
correctly calculate _config

### DIFF
--- a/sacred/initialize.py
+++ b/sacred/initialize.py
@@ -137,7 +137,7 @@ class Scaffold(object):
 
         self.fixture = copy(self.config)
         get_fixture_recursive(self)
-        
+
         return self.fixture
 
     def finalize_initialization(self, run):

--- a/sacred/initialize.py
+++ b/sacred/initialize.py
@@ -123,14 +123,21 @@ class Scaffold(object):
         if self.fixture is not None:
             return self.fixture
 
+        def get_fixture_recursive(runner):
+            for sr_path, subrunner in runner.subrunners.items():
+                # I am not sure if it is necessary to trigger all
+                subrunner.get_fixture()
+                get_fixture_recursive(subrunner)
+                sub_fix = copy(subrunner.config)
+                sub_path = sr_path
+                if is_prefix(self.path, sub_path):
+                    sub_path = sr_path[len(self.path):].strip('.')
+                # Note: This might fail if we allow non-dict fixtures
+                set_by_dotted_path(self.fixture, sub_path, sub_fix)
+
         self.fixture = copy(self.config)
-        for sr_path, subrunner in self.subrunners.items():
-            sub_fix = subrunner.get_fixture()
-            sub_path = sr_path
-            if is_prefix(self.path, sub_path):
-                sub_path = sr_path[len(self.path):].strip('.')
-            # Note: This might fail if we allow non-dict fixtures
-            set_by_dotted_path(self.fixture, sub_path, sub_fix)
+        get_fixture_recursive(self)
+        
         return self.fixture
 
     def finalize_initialization(self, run):


### PR DESCRIPTION
Fix for #249.

Any suggestion, where I can put the following test code? (The FileStorageObserver stuff can be dropped.)

```python
import json
import sacred
from sacred.commands import print_config

sub_sub_ing = sacred.Ingredient('sub_sub_ing')
sub_ing = sacred.Ingredient('sub_ing', [sub_sub_ing])
ing = sacred.Ingredient('ing', [sub_ing])
ex = sacred.Experiment('ex', [ing])

obs = sacred.observers.FileStorageObserver.create('sacred')
ex.observers = [obs]

@ex.config
def config():
    a = 1

@ing.config
def config():
    b = 1

@sub_ing.config
def config():
    c = 2

@sub_sub_ing.config
def config():
    d = 3

@sub_sub_ing.capture
def sub_sub_ing_main(_config):
    assert _config == {
        'd': 3
    }, _config
    print(_config)

@sub_ing.capture
def sub_ing_main(_config):
    assert _config == {
        'c': 2,
        'sub_sub_ing': {'d': 3}
    }, _config
    print(_config)

@ing.capture
def ing_main(_config):
    assert _config == {
        'b': 1,
        'sub_sub_ing': {'d': 3},
        'sub_ing': {'c': 2}
    }, _config
    print(_config)

@ex.automain
def main(_config, _run, _id):
    _config.pop('seed')
    assert _config == {
        'a': 1,
        'sub_sub_ing': {'d': 3},
        'sub_ing': {'c': 2},
        'ing': {'b': 1}
    }, _config

    print(_config)
    ing_main()
    sub_ing_main()
    sub_sub_ing_main()
    print_config(_run)
    # Configuration (modified, added, typechanged, doc):
    #   a = 1
    #   seed = 819367840                   # the random seed for this experiment
    #   ing:
    #     b = 1
    #   sub_ing:
    #     c = 2
    #   sub_sub_ing:
    #     d = 3

    with open(f'sacred/{_id}/config.json') as fd:
        config_json = json.load(fd)
        print(config_json)

    config_json.pop('seed')

    assert config_json == {
        'a': 1,
        'sub_sub_ing': {'d': 3},
        'sub_ing': {'c': 2},
        'ing': {'b': 1}
    }, _config
```