### PR TITLE
Fix typo in _add_named_config

### DIFF
--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -198,7 +198,7 @@ class Ingredient(object):
 
     def _add_named_config(self, name, conf):
         if name in self.named_configs:
-            raise KeyError('Configuration name "{}" already in use!')
+            raise KeyError('Configuration name "{}" already in use!'.format(name))
         self.named_configs[name] = conf
 
     @staticmethod


### PR DESCRIPTION
Give the name of the already existing `named_config` when raising the KeyError if another `named_config` already has the same name.