### PR TITLE
capture ValueError exception when git repo is empty

### DIFF
--- a/sacred/dependencies.py
+++ b/sacred/dependencies.py
@@ -143,7 +143,7 @@ def get_commit_if_possible(filename):
             is_dirty = repo.is_dirty()
             commit = repo.head.commit.hexsha
             return path, commit, is_dirty
-        except InvalidGitRepositoryError:
+        except (InvalidGitRepositoryError, ValueError) as e:
             pass
     return None, None, None
 


### PR DESCRIPTION
When a git repo doesn't have any commits and gitpython is installed, the function `get_commit_if_possible` raises ValueError exception because the directory refs/heads/master does not exists.
```
...
File "/sasdata/roliveira/anaconda3/lib/python3.6/site-packages/sacred/dependencies.py", line 144, in get_commit_if_possible
    commit = repo.head.commit.hexsha
  File "/sasdata/roliveira/anaconda3/lib/python3.6/site-packages/git/refs/symbolic.py", line 200, in _get_commit
    obj = self._get_object()
  File "/sasdata/roliveira/anaconda3/lib/python3.6/site-packages/git/refs/symbolic.py", line 193, in _get_object
    return Object.new_from_sha(self.repo, hex_to_bin(self.dereference_recursive(self.repo, self.path)))
  File "/sasdata/roliveira/anaconda3/lib/python3.6/site-packages/git/refs/symbolic.py", line 135, in dereference_recursive
    hexsha, ref_path = cls._get_ref_info(repo, ref_path)
  File "/sasdata/roliveira/anaconda3/lib/python3.6/site-packages/git/refs/symbolic.py", line 184, in _get_ref_info
    return cls._get_ref_info_helper(repo, ref_path)
  File "/sasdata/roliveira/anaconda3/lib/python3.6/site-packages/git/refs/symbolic.py", line 167, in _get_ref_info_helper
    raise ValueError("Reference at %r does not exist" % ref_path)
ValueError: Reference at 'refs/heads/master' does not exist```