### PR TITLE
Fix seeking in multi-byte locales

### DIFF
--- a/sacred/stdout_capturing.py
+++ b/sacred/stdout_capturing.py
@@ -70,7 +70,7 @@ class CapturedStdout(object):
         if self.final is None:
             self.buffer.seek(self.read_position)
             value = self.buffer.read()
-            self.read_position += len(value)
+            self.read_position = self.buffer.tell()
             return value
         else:
             value = self.final


### PR DESCRIPTION
The length of the string returned by read doesn't necessarily match
the number of bytes read from the buffer in multi-byte locales. Using
tell() ensures the right byte position is stored.

This fixes issue #277.