### PR TITLE
Fixed named config overwrite for ingredients #281

### DIFF
--- a/sacred/initialize.py
+++ b/sacred/initialize.py
@@ -89,7 +89,7 @@ class Scaffold(object):
         else:
             nc = self.named_configs[config_name]
 
-        cfg = nc(fixed=self.config_updates,
+        cfg = nc(fixed=self.get_config_updates_recursive(),
                  preset=self.presets,
                  fallback=self.fallback)
 
@@ -119,6 +119,12 @@ class Scaffold(object):
                    for key, value in iterate_flattened(self.config_updates)})
         for cfg_summary in self.summaries:
             self.config_mods.update_from(cfg_summary)
+
+    def get_config_updates_recursive(self):
+        config_updates = self.config_updates.copy()
+        for sr_path, subrunner in self.subrunners.items():
+            config_updates[sr_path] = subrunner.get_config_updates_recursive()
+        return config_updates
 
     def get_fixture(self):
         if self.fixture is not None:

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -137,6 +137,30 @@ def test_experiment_named_config_subingredient():
     assert ex.run(named_configs=['somemod.nsubcfg', 'ncfg']).result == (2, 25)
 
 
+def test_experiment_named_config_subingredient_overwrite():
+    somemod = Ingredient("somemod")
+
+    @somemod.capture
+    def get_answer(a):
+        return a
+
+    ex = Experiment("some_experiment", ingredients=[somemod])
+
+    @ex.named_config
+    def ncfg():
+        somemod = {'a': 1}
+
+    @ex.main
+    def main():
+        return get_answer()
+
+    assert ex.run(named_configs=['ncfg']).result == 1
+    assert ex.run(config_updates={'somemod': {'a': 2}}).result == 2
+    assert ex.run(named_configs=['ncfg'],
+                  config_updates={'somemod': {'a': 2}}
+                  ).result == 2
+
+
 def test_experiment_double_named_config():
     ex = Experiment()
 


### PR DESCRIPTION
Adds config_update of subrunning Scaffolds to fixed when running ConfigScope. Fixes #281