### PR TITLE
fixes to sql.py to get postgres working

### DIFF
--- a/sacred/observers/sql.py
+++ b/sacred/observers/sql.py
@@ -334,7 +334,7 @@ if opt.has_sqlalchemy:  # noqa
         __tablename__ = 'run'
         id = sa.Column(sa.Integer, primary_key=True)
 
-        run_id = sa.Column(sa.String(24))
+        run_id = sa.Column(sa.String(24), unique=True)
 
         command = sa.Column(sa.String(64))
 
@@ -360,7 +360,7 @@ if opt.has_sqlalchemy:  # noqa
         info = sa.Column(sa.Text)
 
         status = sa.Column(sa.Enum("RUNNING", "COMPLETED", "INTERRUPTED",
-                                   "TIMEOUT", "FAILED"))
+                                   "TIMEOUT", "FAILED", name="status_enum"))
 
         host_id = sa.Column(sa.Integer, sa.ForeignKey('host.host_id'))
         host = sa.orm.relationship("Host", backref=sa.orm.backref('runs'))


### PR DESCRIPTION
Hi, 

Running with 
```
ex.observers.append(SqlObserver.create('postgresql://...
```
generated an error constructing the sqlalchemy schema.  Some minor fixes seemed to make installation work.

Ran tox and all tests passed. 

sacred __version__ = "0.7.3"
Python 3.6.4
SQLAlchemy (1.2.7)
psycopg2 (2.7.4)
postgres server 9.6.6
