### PR TITLE
Add Docs badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Sacred
     | *If an experiment is wasted*
     | *God gets quite irate*
 
-|pypi| |py_versions| |license| |doi|
+|pypi| |py_versions| |license| |rtfd| |doi|
 
 |unix_build| |windows_build| |coverage| |code_quality| |codacy|
 


### PR DESCRIPTION
Couldn't figure out immediately if Sacred had docs or not, googling showed the RTD page so thought I'd add the missing RTD badge ;)