### PR TITLE
ENH: Tees directly to temporary file

### DIFF
--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -215,7 +215,7 @@ class FileStorageObserver(RunObserver):
         try:
             metrics_path = os.path.join(self.dir, "metrics.json")
             saved_metrics = json.load(open(metrics_path, 'r'))
-        except IOError as e:
+        except IOError:
             # We haven't recorded anything yet. Start Collecting.
             saved_metrics = {}
 

--- a/sacred/stdout_capturing.py
+++ b/sacred/stdout_capturing.py
@@ -127,11 +127,11 @@ def tee_output_fd():
             # this is done to avoid receiving KeyboardInterrupts (see #149)
             # in Python 3 we could just pass start_new_session=True
             tee_stdout = subprocess.Popen(
-                ['tee', '-a', '/dev/stderr'], preexec_fn=os.setsid,
-                stdin=subprocess.PIPE, stderr=target_fd, stdout=1)
+                ['tee', '-a', target.name], preexec_fn=os.setsid,
+                stdin=subprocess.PIPE, stdout=1)
             tee_stderr = subprocess.Popen(
-                ['tee', '-a', '/dev/stderr'], preexec_fn=os.setsid,
-                stdin=subprocess.PIPE, stderr=target_fd, stdout=2)
+                ['tee', '-a', target.name], preexec_fn=os.setsid,
+                stdin=subprocess.PIPE, stdout=2)
         except (FileNotFoundError, (OSError, AttributeError)):
             # No tee found in this operating system. Trying to use a python
             # implementation of tee. However this is slow and error-prone.

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -266,4 +266,5 @@ def test_captured_out_filter(run, capsys):
     run.main_function.side_effect = print_mock_progress
     with capsys.disabled():
         run()
+        sys.stdout.flush()
     assert run.captured_out == 'progress 9'


### PR DESCRIPTION
This PR should resolve https://github.com/IDSIA/sacred/issues/289. This makes tee output directly to the temporary file.

I also made a small change to `file_storage.py` allow flake8 to pass.