### PR TITLE
Add a command print_named_configs

### DIFF
--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -137,7 +137,7 @@ The name of the command has to be first on the commandline::
 
     >>> ./my_demo.py COMMAND_NAME with seed=123
 
-If the COMMAND_NAME is ommitted it defaults to the main function, but the name
+If the COMMAND_NAME is omitted it defaults to the main function, but the name
 of that function can also explicitly used as the name of the command.
 So for this experiment
 
@@ -262,6 +262,32 @@ The filename can be configured by setting ``config_filename`` like this::
 The format for exporting the config is inferred from the filename and can be
 any format supported for :ref:`config files <config_files>`.
 
+
+.. _print_named_configs:
+
+Print Named Configs
+-------------------
+
+The ``print_named_configs`` command prints all available named configurations.
+Function docstrings for named config functions are copied and displayed colored
+in **grey**.
+For example::
+
+    >> ./named_config print_named_configs
+    INFO - hello_config - Running command 'print_named_configs'
+    INFO - hello_config - Started
+    Named Configurations (doc):
+      rude   # A rude named config
+    INFO - hello_config - Completed after 0:00:00
+
+If no named configs are available for the experiment, an empty list is printed::
+
+    >> ./01_hello_world print_named_configs
+    INFO - 01_hello_world - Running command 'print_named_configs'
+    INFO - 01_hello_world - Started
+    Named Configurations (doc):
+      No named configs
+    INFO - 01_hello_world - Completed after 0:00:00
 
 Custom Commands
 ---------------

--- a/examples/named_config.py
+++ b/examples/named_config.py
@@ -9,6 +9,7 @@ ex = Experiment('hello_config')
 
 @ex.named_config
 def rude():
+    """A rude named config"""
     recipient = "bastard"
     message = "Fuck off you {}!".format(recipient)
 

--- a/sacred/config/config_scope.py
+++ b/sacred/config/config_scope.py
@@ -30,6 +30,7 @@ class ConfigScope(object):
         self._func = func
         self._body_code = get_function_body_code(func)
         self._var_docs = get_config_comments(func)
+        self.__doc__ = self._func.__doc__
 
     def __call__(self, fixed=None, preset=None, fallback=None):
         """

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -14,7 +14,8 @@ from sacred.arg_parser import format_usage, get_config_updates
 from sacred.commandline_options import (
     ForceOption, gather_command_line_options, LoglevelOption)
 from sacred.commands import (help_for_command, print_config,
-                             print_dependencies, save_config)
+                             print_dependencies, save_config,
+                             print_named_configs)
 from sacred.config.signature import Signature
 from sacred.ingredient import Ingredient
 from sacred.initialize import create_run
@@ -82,6 +83,7 @@ class Experiment(Ingredient):
         self.command(print_config, unobserved=True)
         self.command(print_dependencies, unobserved=True)
         self.command(save_config, unobserved=True)
+        self.command(print_named_configs(self), unobserved=True)
         self.observers = []
         self.current_run = None
         self.captured_out_filter = None

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -283,6 +283,23 @@ class Ingredient(object):
             for cmd_name, cmd in ingred.gather_commands():
                 yield cmd_name, cmd
 
+    def gather_named_configs(self):
+        """Collect all named configs from this ingredient and its sub-ingredients.
+
+        Yields
+        ------
+        config_name: str
+            The full (dotted) name of the named config.
+        config: ConfigScope or ConfigDict or basestring
+            The corresponding named config.
+        """
+        for config_name, config in self.named_configs.items():
+            yield self.path + '.' + config_name, config
+
+        for ingred in self.ingredients:
+            for config_name, config in ingred.gather_named_configs():
+                yield config_name, config
+
     def get_experiment_info(self):
         """Get a dictionary with information about this experiment.
 

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -256,6 +256,23 @@ def test_gather_commands(ing):
     assert ('tickle.foo', foo) in commands
 
 
+def test_gather_named_configs(ing):
+    ing2 = Ingredient('ing2', ingredients=[ing])
+
+    @ing.named_config
+    def named_config1():
+        pass
+
+    @ing2.named_config
+    def named_config2():
+        """named config with doc"""
+        pass
+
+    named_configs = list(ing2.gather_named_configs())
+    assert ('ing2.named_config2', named_config2) in named_configs
+    assert ('tickle.named_config1', named_config1) in named_configs
+
+
 def test_config_docs_are_preserved(ing):
     @ing.config
     def ing_cfg():


### PR DESCRIPTION
I found this command very useful, especially when an experiment contains multiple ingredients which define (nested) named configs. This refers to #239 and may be used to print the available named configs when the user requests an unknown config.

This command is added to the main experiment and prints a list of available named configurations. Docstrings for config scopes are copied and printed as additional information for the named config colored in grey. Here's an example of what the output looks like:

```
Named Configurations (doc):
  named_config1
  ingredient2.named_config3
    """
      A docstring with
      mutliple

      lines.

      """
  ingredient2.dict_config
  ingredient1.named_config2   # A beatiful docstring (this is colored in grey)
```

Btw: This is my first pull request so please correct me if I am doing something wrong.