### PR TITLE
ENH: Uses yaml safe_load

### DIFF
--- a/sacred/config/config_files.py
+++ b/sacred/config/config_files.py
@@ -29,7 +29,7 @@ HANDLER_BY_EXT = {
 
 
 if opt.has_yaml:
-    HANDLER_BY_EXT['.yaml'] = Handler(opt.yaml.load, opt.yaml.dump, '')
+    HANDLER_BY_EXT['.yaml'] = Handler(opt.yaml.safe_load, opt.yaml.dump, '')
 
 
 def get_handler(filename):


### PR DESCRIPTION
Switches to using `safe_load` in pyyaml. From the [pyyaml documentation](https://pyyaml.org/wiki/PyYAMLDocumentation):

> Warning: It is not safe to call yaml.load with any data received from an untrusted source! yaml.load is as powerful as pickle.load and so may call any Python function. Check the yaml.safe_load function though.