### PR TITLE
WIP: Error messages

### DIFF
--- a/sacred/config/captured_function.py
+++ b/sacred/config/captured_function.py
@@ -9,9 +9,10 @@ import wrapt
 from sacred.config.custom_containers import FallbackDict
 from sacred.config.signature import Signature
 from sacred.randomness import create_rnd, get_seed
+from sacred.utils import ConfigError, MissingConfigError
 
 
-def create_captured_function(function, prefix=None):
+def create_captured_function(function, prefix=None, ingredient=None):
     sig = Signature(function)
     function.signature = sig
     function.uses_randomness = ("_seed" in sig.arguments or
@@ -21,6 +22,7 @@ def create_captured_function(function, prefix=None):
     function.rnd = None
     function.run = None
     function.prefix = prefix
+    function.ingredient = ingredient
     return captured_function(function)
 
 
@@ -37,13 +39,30 @@ def captured_function(wrapped, instance, args, kwargs):
         options['_rnd'] = create_rnd(options['_seed'])
 
     bound = (instance is not None)
-    args, kwargs = wrapped.signature.construct_arguments(args, kwargs, options,
-                                                         bound)
+    try:
+        args, kwargs = wrapped.signature.construct_arguments(args, kwargs,
+                                                             options,
+                                                             bound)
+    except MissingConfigError as e:
+        if e.func is None:
+            e.func = wrapped
+        raise e
+
     if wrapped.logger is not None:
         wrapped.logger.debug("Started")
         start_time = time.time()
     # =================== run actual function =================================
-    result = wrapped(*args, **kwargs)
+    try:
+        result = wrapped(*args, **kwargs)
+    except ConfigError as e:
+        if not e.__prefix_handled__:
+            if wrapped.prefix:
+                e.conflicting_configs = ('.'.join((wrapped.prefix, str(c))) for
+                                         c in e.conflicting_configs)
+            e.__config_sources__ = wrapped.sources
+            e.__config__ = wrapped.config
+        e.__prefix_handled__ = True
+        raise e
     # =========================================================================
     if wrapped.logger is not None:
         stop_time = time.time()

--- a/sacred/config/config_dict.py
+++ b/sacred/config/config_dict.py
@@ -7,9 +7,10 @@ from sacred.config.utils import dogmatize, normalize_or_die, undogmatize
 
 
 class ConfigDict(object):
-    def __init__(self, d):
+    def __init__(self, d, source=None):
         super(ConfigDict, self).__init__()
         self._conf = normalize_or_die(d)
+        self.config_source = source
 
     def __call__(self, fixed=None, preset=None, fallback=None):
         result = dogmatize(fixed or {})

--- a/sacred/config/config_scope.py
+++ b/sacred/config/config_scope.py
@@ -11,6 +11,7 @@ from tokenize import generate_tokens, tokenize, TokenError, COMMENT
 from copy import copy
 
 from sacred import SETTINGS
+from sacred.config.config_sources import ConfigScopeConfigSource
 from sacred.config.config_summary import ConfigSummary
 from sacred.config.utils import dogmatize, normalize_or_die, recursive_fill_in
 from sacred.config.signature import get_argspec
@@ -28,7 +29,8 @@ class ConfigScope(object):
             "default values are not allowed for ConfigScope functions"
 
         self._func = func
-        self._body_code, self._file_name, self._line_offset = get_function_body_code(func)
+        self._body_code, file_name, line_offset = get_function_body_code(func)
+        self.config_source = ConfigScopeConfigSource.from_filename_and_lineno(file_name, line_offset)
         self._var_docs = get_config_comments(func)
         self.__doc__ = self._func.__doc__
 

--- a/sacred/config/config_scope.py
+++ b/sacred/config/config_scope.py
@@ -28,7 +28,7 @@ class ConfigScope(object):
             "default values are not allowed for ConfigScope functions"
 
         self._func = func
-        self._body_code = get_function_body_code(func)
+        self._body_code, self._file_name, self._line_offset = get_function_body_code(func)
         self._var_docs = get_config_comments(func)
         self.__doc__ = self._func.__doc__
 
@@ -161,7 +161,7 @@ def get_function_body_code(func):
                                   statement.strip(), filename, lineno))
         else:
             raise
-    return body_code
+    return body_code, filename, line_offset
 
 
 def is_ignored(line):

--- a/sacred/config/config_sources.py
+++ b/sacred/config/config_sources.py
@@ -1,0 +1,78 @@
+class ConfigSource:
+    @staticmethod
+    def get_string(config_source, ):
+        if isinstance(config_source, dict):
+            def _get_sources(d):
+                sources = set()
+                if isinstance(d, dict):
+                    for v in config_source.values():
+                        sources.update(_get_sources(v))
+                else:
+                    sources.add(d)
+                return sources
+            sources = _get_sources(config_source)
+            # '\n'.join([s.get_source_string_for_config()])
+        else:
+            return config_source.get_source_string_for_config
+
+    def get_source_string_for_config(self, config=None):
+        raise NotImplementedError()
+
+
+class FileConfigSource(ConfigSource):
+    def __init__(self, file, line=None) -> None:
+        super().__init__()
+        self.file = file
+        self.line = line
+
+    def get_source_string_for_config(self, config=None):
+        if self.line is None:
+            return '"{}"'.format(self.file)
+        else:
+            return '"{}:{}"'.format(self.file, self.line)
+
+
+class ConfigScopeConfigSource(ConfigSource):
+    def __init__(self, config_scope) -> None:
+        super().__init__()
+        self.config_scope = config_scope
+
+    def get_source_string_for_config(self, config=None):
+        return '"{}:{}"'.format(self.config_scope._file_name,
+                              self.config_scope._line_offset)
+
+
+class NamedConfigScopeConfigSource(ConfigScopeConfigSource):
+    def __init__(self, config_name, config_scope):
+        super().__init__(config_scope)
+        self.config_name = config_name
+
+    def get_source_string_for_config(self, config=None):
+        file = super().get_source_string_for_config(config)
+        return 'Named Config "{}" at {}'.format(self.config_name, file)
+
+
+class CommandLineConfigSource(ConfigSource):
+
+    def __init__(self, config_updates) -> None:
+        super().__init__()
+        self.config_updates = config_updates
+
+    def get_source_string_for_config(self, config=None):
+        if config is not None and config in self.config_updates:
+            return 'command line config "{}={}"'.format(config,
+                                                      self.config_updates[
+                                                          config])
+        else:
+            return 'command line config with "{}"'.format(' '.join(
+                '{}={}'.format(k, v) for k, v in self.config_updates.items()))
+
+
+class ConfigDictConfigSource(ConfigSource):
+    def __init__(self, config_dict) -> None:
+        self.config_dict = config_dict
+
+    def get_source_string_for_config(self, config=None):
+        return 'Set in config dict (unknown source)'
+
+

--- a/sacred/config/config_summary.py
+++ b/sacred/config/config_summary.py
@@ -7,13 +7,14 @@ from sacred.utils import iter_prefixes, join_paths
 
 class ConfigSummary(dict):
     def __init__(self, added=(), modified=(), typechanged=(),
-                 ignored_fallbacks=(), docs=()):
+                 ignored_fallbacks=(), docs=(), sources=()):
         super(ConfigSummary, self).__init__()
         self.added = set(added)
         self.modified = set(modified)  # TODO: test for this member
         self.typechanged = dict(typechanged)
         self.ignored_fallbacks = set(ignored_fallbacks)  # TODO: test
         self.docs = dict(docs)
+        self.sources = dict(sources)
         self.ensure_coherence()
 
     def update_from(self, config_mod, path=''):
@@ -40,6 +41,9 @@ class ConfigSummary(dict):
         self.docs.update({join_paths(path, k): v
                           for k, v in config_mod.docs.items()
                           if path == '' or k != 'seed'})
+        self.sources.update({join_paths(path, k): v
+                             for k, v in config_mod.sources.items()
+                             if path == '' or k != 'seed'})
         self.ensure_coherence()
 
     def ensure_coherence(self):

--- a/sacred/config/signature.py
+++ b/sacred/config/signature.py
@@ -6,6 +6,7 @@ import inspect
 from collections import OrderedDict
 import sys
 
+from sacred.utils import MissingConfigError
 
 if sys.version_info[0] < 3:  # python2
     def get_argspec(f):
@@ -156,5 +157,5 @@ class Signature(object):
         free_params = self.get_free_parameters(args, kwargs, bound)
         missing_args = [m for m in free_params if m not in self.kwargs]
         if missing_args:
-            raise TypeError("{} is missing value(s) for {}".format(
-                self.name, missing_args))
+            raise MissingConfigError("{} is missing value(s) for {}".format(
+                self.name, missing_args), missing_configs=missing_args)

--- a/sacred/config/utils.py
+++ b/sacred/config/utils.py
@@ -112,10 +112,7 @@ def chain_evaluate_config_scopes(config_scopes, fixed=None, preset=None,
                      preset=final_config,
                      fallback=fallback)
         config_summaries.append(cfg)
-        if hasattr(config, '_file_name'):
-            source = ConfigScopeConfigSource(config)
-        else:
-            source = ConfigDictConfigSource(config)
+        source = config.config_source
 
         recursive_update(
             config_sources,

--- a/sacred/exception.py
+++ b/sacred/exception.py
@@ -1,0 +1,210 @@
+import inspect
+import sys
+
+colored_exception_output = True
+
+if colored_exception_output:
+    BLUE = '\033[94m'
+    GREEN = '\033[92m'
+    RED = '\033[91m'
+    GREY = '\033[90m'
+    ENDC = '\033[0m'
+else:
+    BLUE = ''
+    GREEN = ''
+    RED = ''
+    GREY = ''
+    ENDC = ''
+
+CONFLICTING = RED
+
+
+from sacred.utils import get_by_dotted_path, iterate_flattened
+
+if sys.version_info[0] == 2:
+    import errno
+
+
+    class FileNotFoundError(IOError):
+        def __init__(self, msg):
+            super(FileNotFoundError, self).__init__(errno.ENOENT, msg)
+else:
+    # Reassign so that we can import it from here
+    FileNotFoundError = FileNotFoundError
+
+
+class ObserverError(Exception):
+    """Error that an observer raises but that should not make the run fail."""
+
+
+class SacredInterrupt(Exception):
+    """Base-Class for all custom interrupts.
+
+    For more information see :ref:`custom_interrupts`.
+    """
+
+    STATUS = "INTERRUPTED"
+
+
+class TimeoutInterrupt(SacredInterrupt):
+    """Signal a that the experiment timed out.
+
+    This exception can be used in client code to indicate that the run
+    exceeded its time limit and has been interrupted because of that.
+    The status of the interrupted run will then be set to ``TIMEOUT``.
+
+    For more information see :ref:`custom_interrupts`.
+    """
+
+    STATUS = "TIMEOUT"
+
+
+class SacredError(Exception):
+    def __init__(self, *args: object, print_traceback=True,
+                 filter_traceback=None, print_usage=False) -> None:
+        super().__init__(*args)
+        self.print_traceback = print_traceback
+        self.filter_traceback = filter_traceback
+        self.print_usage = print_usage
+
+
+class CircularDependencyError(SacredError):
+    """The ingredients of the current experiment form a circular dependency."""
+
+    def __init__(self, *args: object, ingredients=None) -> None:
+        super().__init__(*args)
+        if ingredients is None:
+            ingredients = []
+        self.__ingredients__ = ingredients
+        self.__circular_depencency_handled__ = False
+
+    def __str__(self):
+        return '->'.join([i.path for i in reversed(self.__ingredients__)])
+
+
+class ConfigError(SacredError):
+    def __init__(self, *args, conflicting_configs=(), print_traceback=True,
+                 filter_traceback=True,
+                 print_config_sources=True,
+                 print_usage=False) -> None:
+        super().__init__(*args, print_traceback=print_traceback,
+                         filter_traceback=filter_traceback,
+                         print_usage=print_usage)
+        self.print_config_sources = print_config_sources
+
+        if isinstance(conflicting_configs, str):
+            conflicting_configs = (conflicting_configs,)
+
+        self.conflicting_configs = conflicting_configs
+        self.__prefix_handled__ = False
+        self.__config_sources__ = ()
+        self.__config__ = {}
+
+    def __str__(self):
+        s = super().__str__()
+        if self.print_config_sources:
+            s += '\nConflicting configuration values:'
+            for conflicting_config in self.conflicting_configs:
+                s += '\n  {}{}={}{}'.format(RED, conflicting_config,
+                                       self.__config__[
+                                           conflicting_config], ENDC)
+                s += '\n    defined in {}'.format(
+                        get_by_dotted_path(
+                            self.__config_sources__,
+                            conflicting_config
+                        ).get_source_string_for_config(
+                            conflicting_config
+                        )
+                    )
+        return s
+
+
+class InvalidConfigError(ConfigError):
+    pass
+
+
+class MissingConfigError(SacredError):
+    def __init__(self, *args, missing_configs=(), function=None,
+                 print_traceback=True, filter_traceback=True,
+                 print_usage=True):
+        self.func = function
+        self.missing_configs = missing_configs
+        super().__init__(
+            *args,
+            self.missing_configs,
+            print_traceback=print_traceback,
+            filter_traceback=filter_traceback,
+            print_usage=print_usage
+        )
+
+    def __str__(self):
+        s = str(self.args)
+        if self.func.ingredient is not None:
+            func_file = inspect.getfile(self.func)
+            _, offset = inspect.getsourcelines(self.func)
+
+            captured_func_source = '"{}:{}"'.format(func_file, offset)
+
+            # we can't import Experiment here for `isinstance`, but check
+            # for attribute 'run' should do
+            if hasattr(self.func.ingredient, 'run'):
+                s += '\nFunction that caused the exception: {} captured by ' \
+                     'the experiment "{}" at {}'.format(
+                    self.func,
+                    self.func.ingredient.path,
+                    captured_func_source,
+                )
+            else:
+                s += '\nFunction that caused the exception: {} captured by ' \
+                     'the ingredient "{}" at {}'.format(
+                    self.func,
+                    self.func.ingredient.path,
+                    captured_func_source)
+        else:
+            s += '\nFunction that caused the exception: {}'.format(self.func)
+        return s
+
+
+class NamedConfigNotFoundError(SacredError):
+    def __init__(self, *args, named_config, print_traceback=False,
+                 filter_traceback=None, print_usage=False):
+        super().__init__(
+            *args,
+            print_traceback=print_traceback,
+            filter_traceback=filter_traceback,
+            print_usage=print_usage
+        )
+        self.named_config = named_config
+
+
+class ConfigAddedError(ConfigError):
+    SPECIAL_ARGS = {'_log', '_config', '_seed', '__doc__', 'config_filename', '_run'}
+
+    def __init__(self, *args, conflicting_configs=(), print_traceback=False,
+                 filter_traceback=True, print_config_sources=True,
+                 print_usage=False, print_suggestions=True,
+                 captured_args=()) -> None:
+        args = ('Added new config entry "{}{}{}" that is not used anywhere'.format(CONFLICTING, conflicting_configs[0], ENDC),)
+        super().__init__(*args, conflicting_configs=conflicting_configs,
+                         print_traceback=print_traceback,
+                         filter_traceback=filter_traceback,
+                         print_config_sources=print_config_sources,
+                         print_usage=print_usage,
+                         )
+        self.print_suggestions = print_suggestions
+        self.captured_args = captured_args
+
+    def __str__(self):
+        s = super().__str__()
+        if self.print_suggestions:
+            possible_keys = self.captured_args - self.SPECIAL_ARGS
+
+            for c in self.conflicting_configs:
+                # TODO: get suggestion
+                suggestion = possible_keys.pop()
+                s += '\nDid you mean "{}" instead of "{}"?'.format(suggestion, c)
+        return s
+
+
+
+

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -376,24 +376,12 @@ class Experiment(Ingredient):
         # The same as Run.log_scalar
         return self.current_run.log_scalar(name, value, step)
 
-    def gather_commands(self):
-        """Iterator over all commands of this experiment.
-
-        Also recursively collects all commands from ingredients.
-
-        Yields
-        ------
-        (str, function)
-            A tuple consisting of the (dotted) command-name and the
-            corresponding captured function.
-
-        """
-        for cmd_name, cmd in self.commands.items():
-            yield cmd_name, cmd
-
-        for ingred in self.ingredients:
-            for cmd_name, cmd in ingred.gather_commands():
-                yield cmd_name, cmd
+    def _gather(self, func):
+        for ingredient, _ in self.traverse_ingredients():
+            for name, item in func(ingredient):
+                if ingredient == self:
+                    name = name[len(self.path) + 1:]
+                yield name, item
 
     def get_default_options(self):
         """Get a dictionary of default options as used with run.

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -276,12 +276,15 @@ class Ingredient(object):
         cmd: function
             The corresponding captured function.
         """
-        for cmd_name, cmd in self.commands.items():
-            yield self.path + '.' + cmd_name, cmd
+        return self._gather(
+            lambda ingredient: ((ingredient.path + '.' + command_name, command)
+                                for command_name, command in
+                                ingredient.commands.items()))
 
-        for ingred in self.ingredients:
-            for cmd_name, cmd in ingred.gather_commands():
-                yield cmd_name, cmd
+    def _gather(self, func):
+        for ingredient, _ in self.traverse_ingredients():
+            for item in func(ingredient):
+                yield item
 
     def gather_named_configs(self):
         """Collect all named configs from this ingredient and its sub-ingredients.
@@ -293,12 +296,10 @@ class Ingredient(object):
         config: ConfigScope or ConfigDict or basestring
             The corresponding named config.
         """
-        for config_name, config in self.named_configs.items():
-            yield self.path + '.' + config_name, config
-
-        for ingred in self.ingredients:
-            for config_name, config in ingred.gather_named_configs():
-                yield config_name, config
+        return self._gather(
+            lambda ingredient: ((ingredient.path + '.' + config_name, config)
+                                for config_name, config in
+                                ingredient.commands.items()))
 
     def get_experiment_info(self):
         """Get a dictionary with information about this experiment.

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -353,11 +353,18 @@ class Ingredient(object):
             If a circular structure among ingredients was detected.
         """
         if self._is_traversing:
-            raise CircularDependencyError()
+            raise CircularDependencyError(ingredients=[self])
         else:
             self._is_traversing = True
         yield self, 0
-        for ingredient in self.ingredients:
-            for ingred, depth in ingredient.traverse_ingredients():
-                yield ingred, depth + 1
+        try:
+            for ingredient in self.ingredients:
+                for ingred, depth in ingredient.traverse_ingredients():
+                    yield ingred, depth + 1
+        except CircularDependencyError as e:
+            if not e.__circular_depencency_handled__:
+                if self in e.__ingredients__:
+                    e.__circular_depencency_handled__ = True
+                e.__ingredients__.append(self)
+            raise e
         self._is_traversing = False

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 
 from sacred.config import (ConfigDict, ConfigScope, create_captured_function,
                            load_config_file)
+from sacred.config.config_sources import ConfigDictConfigSource
 from sacred.dependencies import (PEP440_VERSION_PATTERN, PackageDependency,
                                  Source, gather_sources_and_dependencies)
 from sacred.utils import (CircularDependencyError, optional_kwargs_decorator,
@@ -203,20 +204,21 @@ class Ingredient(object):
 
     @staticmethod
     def _create_config_dict(cfg_or_file, kw_conf):
+        source = ConfigDictConfigSource.from_stack(2)
         if cfg_or_file is not None and kw_conf:
             raise ValueError("cannot combine keyword config with "
                              "positional argument")
         if cfg_or_file is None:
             if not kw_conf:
                 raise ValueError("attempted to add empty config")
-            return ConfigDict(kw_conf)
+            return ConfigDict(kw_conf, source)
         elif isinstance(cfg_or_file, dict):
-            return ConfigDict(cfg_or_file)
+            return ConfigDict(cfg_or_file, source)
         elif isinstance(cfg_or_file, basestring):
             if not os.path.exists(cfg_or_file):
                 raise IOError('File not found {}'.format(cfg_or_file))
             abspath = os.path.abspath(cfg_or_file)
-            return ConfigDict(load_config_file(abspath))
+            return ConfigDict(load_config_file(abspath), source)
         else:
             raise TypeError("Invalid argument type {}"
                             .format(type(cfg_or_file)))

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -74,7 +74,8 @@ class Ingredient(object):
         """
         if function in self.captured_functions:
             return function
-        captured_function = create_captured_function(function, prefix=prefix)
+        captured_function = create_captured_function(function, prefix=prefix,
+                                                     ingredient=self)
         self.captured_functions.append(captured_function)
         return captured_function
 

--- a/sacred/utils.py
+++ b/sacred/utils.py
@@ -56,10 +56,18 @@ PATHCHANGE = object()
 
 PYTHON_IDENTIFIER = re.compile("^[a-zA-Z_][_a-zA-Z0-9]*$")
 
-
-class CircularDependencyError(Exception):
+class CircularDependencyError:
     """The ingredients of the current experiment form a circular dependency."""
 
+    def __init__(self, *args, ingredients=None):
+        super().__init__(*args)
+        if ingredients is None:
+            ingredients = []
+        self.__ingredients__ = ingredients
+        self.__circular_depencency_handled__ = False
+
+    def __str__(self):
+        return '->'.join([i.path for i in reversed(self.__ingredients__)])
 
 class ObserverError(Exception):
     """Error that an observer raises but that should not make the run fail."""


### PR DESCRIPTION
This is a WIP pullrequest that addresses the error messages as described in #239. I finally got time to prepare a pullrequest for this.

The code is currently very ugly and could more be seen as a proof of concept that those things can work.

There are lists of things that are already done and that need to be done below.
Any suggestions for further improvement of the error messages (or the code, since some part of it is not well structured and untested) are welcome.

# Done

## Use iterate_ingredients for gathering commands and named configs

This causes `gather_commands` and `gather_named_configs` to raise a `CircularDependencyError` instead of a `RecursionError`, which makes much clearer what is causing the error.
In addition, any future `gather_something` functions that may be implemented can overwrite one method and the error handling is done in `iterate_ingredients`, and the path filtering for experiments is done there.

## Track Ingredients that cause circular dependencies

The `CircularDependencyError` is caught in `iterate_ingredients` and the current ingredient is added to a list `CircularDependencyError.__ingredients__` to keep track of which ingrediens cuased the circular depenceny.

An example error:
```
Traceback (most recent call last):
  File "error_messages.py", line 24, in <module>
    @ex.automain
  File ".../sacred/experiment.py", line 141, in automain
    self.run_commandline()
  File ".../sacred/experiment.py", line 248, in run_commandline
    short_usage, usage, internal_usage = self.get_usage()
  File ".../sacred/experiment.py", line 173, in get_usage
    commands = OrderedDict(self.gather_commands())
  File ".../sacred/experiment.py", line 394, in _gather
    for ingredient, _ in self.traverse_ingredients():
  File ".../sacred/ingredient.py", line 370, in traverse_ingredients
    raise e
  File ".../sacred/ingredient.py", line 363, in traverse_ingredients
    for ingred, depth in ingredient.traverse_ingredients():
  File ".../sacred/ingredient.py", line 370, in traverse_ingredients
    raise e
  File ".../sacred/ingredient.py", line 363, in traverse_ingredients
    for ingred, depth in ingredient.traverse_ingredients():
  File ".../sacred/ingredient.py", line 370, in traverse_ingredients
    raise e
  File ".../sacred/ingredient.py", line 363, in traverse_ingredients
    for ingred, depth in ingredient.traverse_ingredients():
  File ".../sacred/ingredient.py", line 357, in traverse_ingredients
    raise CircularDependencyError(ingredients=[self])
sacred.exception.CircularDependencyError: ing->ing2->ing
```

## Track sources of configuration entries

This code is still very ugly, but it allows to track the sources of configuration values.
This works up to different resolutions:

 - for a `ConfigScope`, we can find the wrapped function and get the place of definition of this function (file + line of the signature line)
 - for a configuration file we can find the file that defines the configuration values. It would be very difficult to get the line of the config value inside of the file.
 - for a dict config, we can use `inspect.stack` to find the line in which the dict configuration value was added.
 - for configuration defined in the command line, we can say that it was defined in the command line options

See the `InvalidConfigError` for examples.

## Add a baseclass `SacredError` for future Excpetions that is pretty printed in `experiment.run_commandline`

The init definition looks like this:

```python
def __init__(self, *args, print_traceback=True,
                 filter_traceback=None, print_usage=False):
    # ...
```

It provides the following additional arguments (that are handled in `experiment.run_commandline`):

 - `print_traceback`: if `True`, traceback is printed according to `filter_traceback`. If `False`, no traceback is printed (except for the Exception itself)
 - `filter_traceback`: If `True`, the traceback is filtered (WITHOUT sacred internals), if `False`, it is not filtered and if `None`, it falls back to the previous behaviour (filter if not raised within sacred)
 - `print_usage`: The short usage is printed when this is set to `True`.

## Add an `InvalidConfigError` that can be raised in user code

Added an `InvalidConfigError` that prints the conflicting configuration values.

Example:

```python
ex = Experiment()

@ex.config
def config():
    config1 = 123
    config2 = dict(a=234)

@ex.automain
def main(config1, config2):
  if not type(config1) == type(config2['a']):
    raise InvalidConfigError('Must have same type', conflicting_configs=('config1', 'config2.a'))
```

```
$ python error_messages.py with config1=abcde

WARNING - root - Changed type of config entry "config1" from int to str
WARNING - error_messages - No observers have been added to this run
INFO - error_messages - Running command 'main'
INFO - error_messages - Started
ERROR - error_messages - Failed after 0:00:00!
Traceback (most recent calls WITHOUT Sacred internals):
  File ".../wrapt/wrappers.py", line 523, in __call__
    args, kwargs)
  File "error_messages.py", line 27, in main
    raise InvalidConfigError('Must have same type', conflicting_configs=('config1', 'config2.a'))
sacred.exception.InvalidConfigError: Must have same type
Conflicting configuration values:
  config1=abcde
    defined in command line config "config1=abcde"
  config2.a=234
    defined in "error_messages.py:20"
```

## MissingConfigError

Prints missing configuration values. Prints the filtered stack trace by default, so that the function call that is missing values can be found.
It also prints the name of the ingredient that captured the function and the file in which the captured function is defined.

Example error:

```
Traceback (most recent calls WITHOUT Sacred internals):
  File .../wrapt/wrappers.py", line 523, in __call__
    args, kwargs)
sacred.exception.MissingConfigError: main is missing value(s) for ['config3']
Function that caused the exception: <function main at 0x0F7A0780> captured by the experiment "error_messages" at "error_messages.py:24"

```

## NamedConfigNotFoundError

Raise a `NamedConfigNotFoundError` instead of `KeyError`, and don't print traceback.

### TODO

 - print list of available named configs
 - give suggestion based on levenshtein distance

## ConfigAddedError

Raise a `ConfigAddedError` when a config value is added that is not used anywhere. This is a sublcass of `ConfigError` and prints the source where the new configuration value is defined:

```
Traceback (most recent call last):
sacred.utils.ConfigAddedError: Added new config entry "unused" that is not used anywhere
Conflicting configuration values:
  unused=3
    defined in command line config "unused=3"
Did you mean "config1" instead of "unused"
```

### TODO

 - print suggestions based on levenshtein distance

# TODO

 - print suggestions for `ConfigAddedError`
 - (colored exception output?)
 - make source tracking optional in SETTINGS
 - improve resolution of source tracking (line of config file, line in a config scope maybe using inspect.stack)
 - CommandNotFoundError (?)
 - Error when parameter is not present for config scope
 - tests
