### PR TITLE
Enforce consistent mimetypes on windows

### DIFF
--- a/sacred/observers/mongo.py
+++ b/sacred/observers/mongo.py
@@ -8,6 +8,7 @@ import os.path
 import sys
 import time
 import mimetypes
+mimetypes.init(files=[])  # This ensures consistent mimetype detection across platforms.
 
 import sacred.optional as opt
 from sacred.commandline_options import CommandLineOption

--- a/sacred/observers/mongo.py
+++ b/sacred/observers/mongo.py
@@ -8,7 +8,6 @@ import os.path
 import sys
 import time
 import mimetypes
-mimetypes.init(files=[])  # This ensures consistent mimetype detection across platforms.
 
 import sacred.optional as opt
 from sacred.commandline_options import CommandLineOption
@@ -18,6 +17,9 @@ from sacred.serializer import flatten
 from sacred.utils import ObserverError
 
 DEFAULT_MONGO_PRIORITY = 30
+
+# This ensures consistent mimetype detection across platforms.
+mimetypes.init(files=[])
 
 
 def force_valid_bson_key(key):


### PR DESCRIPTION
Preventing systems defaults may fix the issue of different mimetypes being detected on Linux and Windows. See https://docs.python.org/3.7/library/mimetypes.html#mimetypes.init