### PR TITLE
Fix ResourceWarning: unclosed file in heartbeat process

### DIFF
--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -216,7 +216,8 @@ class FileStorageObserver(RunObserver):
         """
         try:
             metrics_path = os.path.join(self.dir, "metrics.json")
-            saved_metrics = json.load(open(metrics_path, 'r'))
+            with open(metrics_path, 'r') as f:
+                saved_metrics = json.load(f)
         except IOError:
             # We haven't recorded anything yet. Start Collecting.
             saved_metrics = {}


### PR DESCRIPTION
I get regular warnings (approx every two seconds) when running sacred on my Python installation (3.6.5).
```
XXX/lib/python3.6/site-packages/sacred/observers/file_storage.py:217: ResourceWarning: unclosed file <_io.TextIOWrapper name='sacred_runs/2/metrics
.json' mode='r' encoding='UTF-8'>
  saved_metrics = json.load(open(metrics_path, 'r'))
XXX/lib/python3.6/site-packages/sacred/observers/file_storage.py:217: ResourceWarning: unclosed file <_io.TextIOWrapper name='sacred_runs/2/metrics
.json' mode='r' encoding='UTF-8'>
  saved_metrics = json.load(open(metrics_path, 'r'))
XXX/lib/python3.6/site-packages/sacred/observers/file_storage.py:217: ResourceWarning: unclosed file <_io.TextIOWrapper name='sacred_runs/2/metrics
.json' mode='r' encoding='UTF-8'>
```
It seems as if the heartbeat process is not closing the metrics file after opening it to read the most recent version (thus the reoccurring warning every two seconds).
The pull request fixes this behaviour by using a context manager to automatically close the file after reading.