### PR TITLE
Add a generic gathering function to Ingredient

### DIFF
--- a/sacred/commands.py
+++ b/sacred/commands.py
@@ -76,11 +76,9 @@ def _format_named_config(indent, path, named_config):
     return indent + assign
 
 
-def _format_named_configs(named_configs, indent=2, hide_path=None):
+def _format_named_configs(named_configs, indent=2):
     lines = ['Named Configurations (' + GREY + 'doc' + ENDC + '):']
     for path, named_config in named_configs.items():
-        if hide_path is not None and path.startswith(hide_path + '.'):
-            path = path[len(hide_path) + 1:]
         lines.append(_format_named_config(indent, path, named_config))
     if len(lines) < 2:
         lines.append(' ' * indent + 'No named configs')
@@ -100,7 +98,7 @@ def print_named_configs(ingredient):
     def print_named_configs():
         """Print the available named configs and exit."""
         named_configs = OrderedDict(ingredient.gather_named_configs())
-        print(_format_named_configs(named_configs, 2, ingredient.path))
+        print(_format_named_configs(named_configs, 2))
 
     return print_named_configs
 

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -7,12 +7,14 @@ import os.path
 
 from collections import OrderedDict
 
+import wrapt
+
 from sacred.config import (ConfigDict, ConfigScope, create_captured_function,
                            load_config_file)
 from sacred.dependencies import (PEP440_VERSION_PATTERN, PackageDependency,
                                  Source, gather_sources_and_dependencies)
 from sacred.utils import (CircularDependencyError, optional_kwargs_decorator,
-                          basestring)
+                          basestring, join_paths)
 
 __all__ = ('Ingredient',)
 
@@ -20,6 +22,20 @@ __all__ = ('Ingredient',)
 def collect_repositories(sources):
     return [{'url': s.repo, 'commit': s.commit, 'dirty': s.is_dirty}
             for s in sources if s.repo]
+
+
+@wrapt.decorator
+def gather_from_ingredients(wrapped, instance=None, args=None, kwargs=None):
+    """
+    Decorator that calls `_gather` on the instance the wrapped function is
+    bound to (should be an `Ingredient`) and yields from the returned
+    generator.
+
+    This function is necessary, because `Ingredient._gather` cannot directly be
+    used as a decorator inside of `Ingredient`.
+    """
+    for item in instance._gather(wrapped):
+        yield item
 
 
 class Ingredient(object):
@@ -266,7 +282,22 @@ class Ingredient(object):
             raise ValueError('Invalid Version: "{}"'.format(version))
         self.dependencies.add(PackageDependency(package_name, version))
 
-    def gather_commands(self):
+    def _gather(self, func):
+        """
+        Function needed and used by gathering functions through the decorator
+        `gather_from_ingredients` in `Ingredient`. Don't use this function by
+        itself outside of the decorator!
+
+        By overwriting this function you can filter what is visible when
+        gathering something (e.g. commands). See `Experiment._gather` for an
+        example.
+        """
+        for ingredient, _ in self.traverse_ingredients():
+            for item in func(ingredient):
+                yield item
+
+    @gather_from_ingredients
+    def gather_commands(self, ingredient):
         """Collect all commands from this ingredient and its sub-ingredients.
 
         Yields
@@ -276,15 +307,13 @@ class Ingredient(object):
         cmd: function
             The corresponding captured function.
         """
-        for cmd_name, cmd in self.commands.items():
-            yield self.path + '.' + cmd_name, cmd
+        for command_name, command in ingredient.commands.items():
+            yield join_paths(ingredient.path, command_name), command
 
-        for ingred in self.ingredients:
-            for cmd_name, cmd in ingred.gather_commands():
-                yield cmd_name, cmd
-
-    def gather_named_configs(self):
-        """Collect all named configs from this ingredient and its sub-ingredients.
+    @gather_from_ingredients
+    def gather_named_configs(self, ingredient):
+        """Collect all named configs from this ingredient and its
+        sub-ingredients.
 
         Yields
         ------
@@ -293,12 +322,8 @@ class Ingredient(object):
         config: ConfigScope or ConfigDict or basestring
             The corresponding named config.
         """
-        for config_name, config in self.named_configs.items():
-            yield self.path + '.' + config_name, config
-
-        for ingred in self.ingredients:
-            for config_name, config in ingred.gather_named_configs():
-                yield config_name, config
+        for config_name, config in ingredient.named_configs.items():
+            yield join_paths(ingredient.path, config_name), config
 
     def get_experiment_info(self):
         """Get a dictionary with information about this experiment.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -209,7 +209,7 @@ def test_format_named_configs():
     ingred.add_named_config('dict_config', dict_config)
 
     named_configs_text = _format_named_configs(OrderedDict(
-        ex.gather_named_configs()), hide_path=ex.path)
+        ex.gather_named_configs()))
     assert named_configs_text.startswith('Named Configurations (' +
                                             GREY + 'doc' + ENDC + '):')
     assert 'named_config2' in named_configs_text


### PR DESCRIPTION
This is the first part of #348. It adds the generic gathering function to the `Ingredient` so that all gathering functions raise a `CircularDependencyError` if a circular dependency exists and reduces code duplication. It also simplifies the creation of new gathering functions by introducing a decorator `gather_from_ingredients`:

```python
class Ingredient:
    # ...
    @gather_from_ingredients
    def gather_something(self, ingredient):
        # generator that yields something for ingredient
        yield ingredient.that_something
```

And, it removes obsolete code from `print_named_configs` command, that now is replaced by the new gathering functionality.