### PR TITLE
Add proxy support to Telegram observer.

### DIFF
--- a/docs/observers.rst
+++ b/docs/observers.rst
@@ -672,6 +672,12 @@ or pickle file containing...
   * optionally: a boolean for ``silent_completion``. If set to true, regular experiment completions
     will use no or less intrusive notifications, depending on the receiving device's platform.
     Experiment starts will always be sent silently, interruptions and failures always with full notifications.
+  * optionally: a string for ``proxy_url``. Specify this field, if Telegram is blocked in the local network or
+    in the country, and you want to use proxy server.
+    Format: ``PROTOCOL://PROXY_HOST:[PROXY_PORT]/``. Socks5 and HTTP protocols are supported.
+    These settings also could be received from ``HTTPS_PROXY`` or ``https_proxy`` environment variable.
+  * optionally: ``username`` for proxy.
+  * optionally: ``password`` for proxy.
 
 The observer is then added to the experment like this:
 

--- a/sacred/observers/telegram_obs.py
+++ b/sacred/observers/telegram_obs.py
@@ -54,8 +54,37 @@ class TelegramObserver(RunObserver):
         import telegram
         d = load_config_file(filename)
         obs = None
+
+        if 'proxy_url' in d:
+            from telegram.utils.request import Request
+
+            if d['proxy_url'].startswith('socks5'):
+                urllib3_proxy_kwargs = dict()
+                for key in ['username', 'password']:
+                    if key in d:
+                        urllib3_proxy_kwargs[key] = d[key]
+                request = Request(proxy_url=d['proxy_url'], urllib3_proxy_kwargs=urllib3_proxy_kwargs)
+            elif d['proxy_url'].startswith('http'):
+                cred_string = ''
+                if 'username' in d:
+                    cred_string += d['username']
+                if 'password' in d:
+                    cred_string += ':' + d['password']
+                if len(cred_string) > 0:
+                    domain = d['proxy_url'].split('/')[-1].split('@')[-1]
+                    cred_string += '@'
+                    proxy_url = 'http://{}{}'.format(cred_string, domain)
+                    request = Request(proxy_url=proxy_url)
+                else:
+                    request = Request(proxy_url=d['proxy_url'])
+            else:
+                raise Exception("Proxy URL should be in format PROTOCOL://PROXY_HOST[:PROXY_PORT].\n"
+                                "HTTP and Socks5 are supported.")
+        else:
+            request = None
+
         if 'token' in d and 'chat_id' in d:
-            bot = telegram.Bot(d['token'])
+            bot = telegram.Bot(d['token'], request=request)
             obs = cls(bot, **d)
         else:
             raise ValueError("Telegram configuration file must contain "


### PR DESCRIPTION
Hi.
I added proxy support to Telegram observer. Didn't test on http proxy with password though, in other cases works properly.