### PR TITLE
Ensure that FileStorageObserver's save_cout appends new console output

### DIFF
--- a/sacred/__about__.py
+++ b/sacred/__about__.py
@@ -11,7 +11,7 @@ from __future__ import division, print_function, unicode_literals
 
 __all__ = ("__version__", "__author__", "__author_email__", "__url__")
 
-__version__ = "0.7.4"
+__version__ = "0.7.4-onurgu"
 
 __author__ = 'Klaus Greff'
 __author_email__ = 'klaus.greff@startmail.com'

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -128,6 +128,7 @@ class FileStorageObserver(RunObserver):
         self.config = config
         self.info = {}
         self.cout = ""
+        self.cout_write_cursor = 0
 
         self.save_json(self.run_entry, 'run.json')
         self.save_json(self.config, 'config.json')

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -49,6 +49,7 @@ class FileStorageObserver(RunObserver):
         self.config = None
         self.info = None
         self.cout = ""
+        self.cout_write_cursor = 0
 
     def queued_event(self, ex_info, command, host_info, queue_time, config,
                      meta_info, _id):
@@ -154,8 +155,9 @@ class FileStorageObserver(RunObserver):
         copyfile(filename, os.path.join(self.dir, target_name))
 
     def save_cout(self):
-        with open(os.path.join(self.dir, 'cout.txt'), 'wb') as f:
-            f.write(self.cout.encode('utf-8'))
+        with open(os.path.join(self.dir, 'cout.txt'), 'a', encoding="utf-8") as f:
+            f.write(self.cout[self.cout_write_cursor:])
+            self.cout_write_cursor = len(self.cout)
 
     def render_template(self):
         if opt.has_mako and self.template:

--- a/tests/test_observers/test_file_storage_observer.py
+++ b/tests/test_observers/test_file_storage_observer.py
@@ -159,6 +159,32 @@ def test_fs_observer_heartbeat_event_updates_run(dir_obs, sample_run):
     assert info == i
 
 
+def test_fs_observer_heartbeat_event_multiple_updates_run(dir_obs, sample_run):
+    basedir, obs = dir_obs
+    _id = obs.started_event(**sample_run)
+    run_dir = basedir.join(_id)
+    info = {'my_info': [1, 2, 3], 'nr': 7}
+
+    captured_outs = [ ("some output %d\n" % i) for i in range(10)]
+    beat_times = [(T2 + datetime.timedelta(seconds=i*10)) for i in range(10)]
+
+    for idx in range(len(beat_times)):
+        expected_captured_output = "\n".join([x.strip() for x in captured_outs[:(idx+1)]]) + "\n"
+        obs.heartbeat_event(info=info, captured_out=expected_captured_output,
+                                                              beat_time=beat_times[idx],
+                                                              result=17)
+
+        assert run_dir.join('cout.txt').read() == expected_captured_output
+        run = json.loads(run_dir.join('run.json').read())
+
+        assert run['heartbeat'] == beat_times[idx].isoformat()
+        assert run['result'] == 17
+
+        assert run_dir.join('info.json').exists()
+        i = json.loads(run_dir.join('info.json').read())
+        assert info == i
+
+
 def test_fs_observer_completed_event_updates_run(dir_obs, sample_run):
     basedir, obs = dir_obs
     _id = obs.started_event(**sample_run)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36, flake8
+envlist = py27, py35, py36, flake8, py37
 # py32 does not work because of the 'wrapt' dependency
 # py33 is not supported by newer versions of numpy
 


### PR DESCRIPTION
I got a feedback from a system administrator that my process was displaying a strange file system usage pattern. When I investigated this, I have seen that issue #383 was the culprit.

So I commited this change to solve this problem.