### PR TITLE
Add SignatureError

### DIFF
--- a/sacred/config/signature.py
+++ b/sacred/config/signature.py
@@ -6,7 +6,7 @@ import inspect
 from collections import OrderedDict
 import sys
 
-from sacred.utils import MissingConfigError
+from sacred.utils import MissingConfigError, SignatureError
 
 if sys.version_info[0] < 3:  # python2
     def get_argspec(f):
@@ -127,7 +127,7 @@ class Signature(object):
     def _assert_no_unexpected_args(self, expected_args, args):
         if not self.vararg_name and len(args) > len(expected_args):
             unexpected_args = args[len(expected_args):]
-            raise TypeError("{} got unexpected argument(s): {}".format(
+            raise SignatureError("{} got unexpected argument(s): {}".format(
                 self.name, unexpected_args))
 
     def _assert_no_unexpected_kwargs(self, expected_args, kwargs):
@@ -135,15 +135,16 @@ class Signature(object):
             return
         unexpected_kwargs = set(kwargs) - set(expected_args)
         if unexpected_kwargs:
-            raise TypeError("{} got unexpected kwarg(s): {}".format(
+            raise SignatureError("{} got unexpected kwarg(s): {}".format(
                 self.name, sorted(unexpected_kwargs)))
 
     def _assert_no_duplicate_args(self, expected_args, args, kwargs):
         positional_arguments = expected_args[:len(args)]
         duplicate_arguments = [v for v in positional_arguments if v in kwargs]
         if duplicate_arguments:
-            raise TypeError("{} got multiple values for argument(s) {}".format(
-                self.name, duplicate_arguments))
+            raise SignatureError(
+                "{} got multiple values for argument(s) {}".format(
+                    self.name, duplicate_arguments))
 
     def _fill_in_options(self, args, kwargs, options, bound):
         free_params = self.get_free_parameters(args, kwargs, bound)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -64,7 +64,14 @@ def test_format_filtered_stacktrace_true():
     try:
         f()
     except:
-        st = format_filtered_stacktrace(filter_traceback=True)
+        st = format_filtered_stacktrace(filter_traceback='default')
+        assert 'captured_function' not in st
+        assert 'WITHOUT Sacred internals' in st
+
+    try:
+        f()
+    except:
+        st = format_filtered_stacktrace(filter_traceback='always')
         assert 'captured_function' not in st
         assert 'WITHOUT Sacred internals' in st
 
@@ -79,24 +86,29 @@ def test_format_filtered_stacktrace_false():
     try:
         f()
     except:
-        st = format_filtered_stacktrace(filter_traceback=False)
+        st = format_filtered_stacktrace(filter_traceback='never')
         assert 'captured_function' in st
 
 
 @pytest.mark.parametrize(
     'print_traceback,filter_traceback,print_usage,expected', [
-        (False, False, False, '.*SacredError: message'),
-        (True, False, False, r'Traceback \(most recent call last\):\n*'
-                             r'\s*File ".*", line \d*, in '
-                             r'test_format_sacred_error\n*'
-                             r'.*\n*'
-                             r'.*SacredError: message'),
-        (False, True, False, r'.*SacredError: message'),
-        (False, False, True, r'usage\n.*SacredError: message'),
-        (True, True, False, r'Traceback \(most recent calls WITHOUT Sacred '
-                            r'internals\):\n*'
-                            r'(\n|.)*'
-                            r'.*SacredError: message')
+        (False, 'never', False, '.*SacredError: message'),
+        (True, 'never', False, r'Traceback \(most recent call last\):\n*'
+                               r'\s*File ".*", line \d*, in '
+                               r'test_format_sacred_error\n*'
+                               r'.*\n*'
+                               r'.*SacredError: message'),
+        (False, 'default', False, r'.*SacredError: message'),
+        (False, 'always', False, r'.*SacredError: message'),
+        (False, 'never', True, r'usage\n.*SacredError: message'),
+        (True, 'default', False, r'Traceback \(most recent calls WITHOUT '
+                                 r'Sacred internals\):\n*'
+                                 r'(\n|.)*'
+                                 r'.*SacredError: message'),
+        (True, 'always', False, r'Traceback \(most recent calls WITHOUT '
+                                r'Sacred internals\):\n*'
+                                r'(\n|.)*'
+                                r'.*SacredError: message')
     ])
 def test_format_sacred_error(print_traceback, filter_traceback, print_usage,
                              expected):
@@ -105,5 +117,4 @@ def test_format_sacred_error(print_traceback, filter_traceback, print_usage,
                           print_usage)
     except SacredError as e:
         st = format_sacred_error(e, 'usage')
-        print(st)
         assert re.match(expected, st, re.MULTILINE)


### PR DESCRIPTION
Adds a `SignatureError` that is raised when the passed config and arguments do not match the signature of a captured function. It inherits from `TypeError`, so any check for this still works and is consistent with Python errors.
Also adds more advanced options for `filter_traceback` that allow `SacredErrors` to always (except for debugging) suppress sacred internal stacktrace, even if the Exception was raised from within sacred. This now applies to the new `SignatureError` that is raised from within sacred, but the point of interest is the calling function.