### PR TITLE
Use update_one instead of replace_one in mongo observer.

### DIFF
--- a/sacred/observers/mongo.py
+++ b/sacred/observers/mongo.py
@@ -270,8 +270,8 @@ class MongoObserver(RunObserver):
         import pymongo.errors
 
         try:
-            self.runs.replace_one({'_id': self.run_entry['_id']},
-                                  self.run_entry)
+            self.runs.update_one({'_id': self.run_entry['_id']},
+                                 {'$set': self.run_entry})
         except pymongo.errors.AutoReconnect:
             pass  # just wait for the next save
         except pymongo.errors.InvalidDocument:
@@ -283,7 +283,8 @@ class MongoObserver(RunObserver):
 
         for i in range(attempts):
             try:
-                self.runs.save(self.run_entry)
+                self.runs.update_one({'_id': self.run_entry['_id']},
+                                     {'$set': self.run_entry}, upsert=True)
                 return
             except pymongo.errors.AutoReconnect:
                 if i < attempts - 1:


### PR DESCRIPTION
Replace_one rewrites the whole record. This will overwrite changes made
by other applications such as omniboard (see
vivekratnavel/omniboard#39).
Using update_one only updates entries without creating a new record.

In final_save, a save api call is made. I am not sure if here the update
command covers all edge cases.