### PR TITLE
fix exception with compiled pybind11 extension

### DIFF
--- a/sacred/dependencies.py
+++ b/sacred/dependencies.py
@@ -401,7 +401,7 @@ def iterate_sys_modules():
 def get_sources_from_modules(module_iterator, base_path):
     sources = set()
     for modname, mod in module_iterator:
-        if not hasattr(mod, '__file__'):
+        if not getattr(mod, '__file__', None):
             continue
 
         filename = os.path.abspath(mod.__file__)
@@ -415,7 +415,7 @@ def get_sources_from_modules(module_iterator, base_path):
 def get_dependencies_from_modules(module_iterator, base_path):
     dependencies = set()
     for modname, mod in module_iterator:
-        if hasattr(mod, '__file__') and is_local_source(
+        if getattr(mod, '__file__', None) and is_local_source(
                 os.path.abspath(mod.__file__), modname, base_path):
             continue
         if modname.startswith('_') or '.' in modname:

--- a/tests/dependency_example.py
+++ b/tests/dependency_example.py
@@ -8,7 +8,7 @@ from __future__ import division, print_function, unicode_literals
 import mock
 import pytest
 
-from tests.foo import bar
+from tests.foo import bar, mock_extension
 
 
 # Actually this would not work :(

--- a/tests/foo/mock_extension.py
+++ b/tests/foo/mock_extension.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# coding=utf-8
+"""
+This source should not be gathered. It is a regression test for an
+exception that happened if a custom pybind11 extension was present.
+"""
+from __future__ import division, print_function, unicode_literals
+
+__file__ = None


### PR DESCRIPTION
Not attempting to collect c++ sources, just making sure everything else still works. The exception was:

TypeError: expected str, bytes or os.PathLike object, not NoneType

Apparently, my compiled extension has a __file__ attribute, but it is set to None. I'm pretty close to pybind11 "hello world", so quite sure I'm not doing anything unusual (apart from using sacred with my own c++ code).