### PR TITLE
Exempt some labels from stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,10 +5,17 @@ daysUntilStale: 30
 daysUntilClose: 7
 
 # Issues with these labels will never be considered stale
- exemptLabels: []
+exemptLabels:
+  - feature
+  - bug
+  - documentation
+  - high priority
+  - in progress
+  - question
+  - refactoring
 
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true


### PR DESCRIPTION
I think stalebot is best used for questions that are answered and not
closed. For issues that are given labels and therefore are accepted as
significant by maintainers, we should not just close them. Therefore
most labels are exempt now.