### PR TITLE
Improve get_handler exception msg

### DIFF
--- a/sacred/config/config_files.py
+++ b/sacred/config/config_files.py
@@ -39,7 +39,8 @@ def get_handler(filename):
         return HANDLER_BY_EXT[extension]
     except KeyError:
         raise ValueError(
-            'Configuration file "{}" has invalid or unsupported extension "{}".'.format(filename, extension)
+            'Configuration file "{}" has invalid or unsupported extension '
+            '"{}".'.format(filename, extension)
         )
 
 

--- a/sacred/config/config_files.py
+++ b/sacred/config/config_files.py
@@ -35,7 +35,12 @@ if opt.has_yaml:
 
 def get_handler(filename):
     _, extension = os.path.splitext(filename)
-    return HANDLER_BY_EXT[extension]
+    try:
+        return HANDLER_BY_EXT[extension]
+    except KeyError:
+        raise ValueError(
+            '"{}" has invalid or unsupported extention'.format(filename)
+        )
 
 
 def load_config_file(filename):

--- a/sacred/config/config_files.py
+++ b/sacred/config/config_files.py
@@ -39,7 +39,7 @@ def get_handler(filename):
         return HANDLER_BY_EXT[extension]
     except KeyError:
         raise ValueError(
-            '"{}" has invalid or unsupported extention'.format(filename)
+            'Configuration file "{}" has invalid or unsupported extension "{}".'.format(filename, extension)
         )
 
 

--- a/tests/test_config/test_config_files.py
+++ b/tests/test_config/test_config_files.py
@@ -41,9 +41,6 @@ def test_load_config_file(ext, handler):
 def test_load_config_file_exception_msg_invalid_ext():
     handle, f_name = tempfile.mkstemp(suffix='.invalid')
     try:
-        f = os.fdopen(handle, "w")
-        f.close()
-
         exception_msg = re.compile(
             'Configuration file ".*.invalid" has invalid or '
             'unsupported extension ".invalid".'

--- a/tests/test_config/test_config_files.py
+++ b/tests/test_config/test_config_files.py
@@ -3,6 +3,7 @@
 from __future__ import division, print_function, unicode_literals
 
 import os
+import re
 import tempfile
 import pytest
 
@@ -35,3 +36,20 @@ def test_load_config_file(ext, handler):
     d = load_config_file(f_name)
     assert d == data
     os.remove(f_name)
+
+
+def test_load_config_file_exception_msg_invalid_ext():
+    handle, f_name = tempfile.mkstemp(suffix='.invalid')
+    try:
+        f = os.fdopen(handle, "w")
+        f.close()
+
+        exception_msg = re.compile(
+            'Configuration file ".*.invalid" has invalid or '
+            'unsupported extension ".invalid".'
+        )
+        with pytest.raises(ValueError) as excinfo:
+            load_config_file(f_name)
+        assert exception_msg.match(excinfo.value.args[0])
+    finally:
+        os.remove(f_name)

--- a/tests/test_config/test_config_files.py
+++ b/tests/test_config/test_config_files.py
@@ -40,6 +40,8 @@ def test_load_config_file(ext, handler):
 
 def test_load_config_file_exception_msg_invalid_ext():
     handle, f_name = tempfile.mkstemp(suffix='.invalid')
+    f = os.fdopen(handle, "w")  # necessary for windows
+    f.close()
     try:
         exception_msg = re.compile(
             'Configuration file ".*.invalid" has invalid or '


### PR DESCRIPTION
I have sometimes folders in a directory that are identical to named configs. The exception
```
Traceback (most recent call last):
...
  File ".../sacred/config/config_files.py", line 55, in get_handler
    return HANDLER_BY_EXT[extension]
KeyError: ''
```
does not help.

This PR improve the exception msg.