### PR TITLE
Ignore folders that have the same name as a named_config

### DIFF
--- a/sacred/initialize.py
+++ b/sacred/initialize.py
@@ -83,7 +83,7 @@ class Scaffold(object):
         self.fallback.revelation()
 
     def run_named_config(self, config_name):
-        if os.path.exists(config_name):
+        if os.path.isfile(config_name):
             nc = ConfigDict(load_config_file(config_name))
         else:
             if config_name not in self.named_configs:


### PR DESCRIPTION
`load_config_file` assumed that the argument is a file.
Using `isfile` instead of `exists` considers this expectation in `run_named_config` to distinguish named_configs from config_files.

Folders can have the same name as a named_config. This causes an unnecessary error and is solved with this PR.