### PR TITLE
Extend max-line-length for flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,4 @@ pep8ignore =
     sacred.egg-info/* ALL
 [flake8]
 ignore = D100,D101,D102,D103,D104,D105,D203,D401,F821,W504,E722
+max-line-length = 88


### PR DESCRIPTION
I tend to find the current 79 spaces a bit to restrictive and I already
saw some code that looked perfectly readable but still failed the CI
because of too long lines. Therefore I think we should allow a bit more
space.