### PR TITLE
Fixes #442: config_hook overwritten by config_updates

### DIFF
--- a/docs/ingredients.rst
+++ b/docs/ingredients.rst
@@ -182,12 +182,14 @@ Configuration hooks are executed during initialization and can be used to update
 
     @ex.config_hook
     def hook(config, command_name, logger):
-        config.update({'hook': True})
-        return config
+        # Return a dictionary of updates
+        return {'hook': True}
 
     @ex.automain
     def main(hook, other_config):
         do_stuff()
 
-The config_hook function always has to take the 3 arguments `config` of the current configuration, `command_name`, which is the command that will be executed, and `logger`.
-Config hooks are run after the configuration of the linked Ingredient (in the example above Experiment `ex`), but before any further ingredient-configurations are run. The dictionary returned by a config hook is used to update the config updates. Note that config hooks are not restricted to the local namespace of the ingredient.
+The config_hook function always has to take the 3 arguments: `config` of the current configuration, `command_name`, which is the command that will be executed, and `logger`.
+Config hooks are run after the configuration of the linked Ingredient (in the example above Experiment `ex`), but before any further ingredient-configurations are run.
+The dictionary returned by a config hook is used to update the config updates, while any insertion/deletion/update of the `config` parameter is ignored.
+Note that config hooks are not restricted to the local namespace of the ingredient.

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -169,13 +169,14 @@ class Ingredient(object):
         Decorator to add a config hook to this ingredient.
 
         Config hooks need to be a function that takes 3 parameters and returns
-        a dictionary:
+        a dictionary of updates:
         (config, command_name, logger) --> dict
 
         Config hooks are run after the configuration of this Ingredient, but
         before any further ingredient-configurations are run.
-        The dictionary returned by a config hook is used to update the
-        config updates.
+        The dictionary returned by a config hook is used to update the config
+        updates, while any insertion/deletion/update of the `config` parameter
+        is ignored.
         Note that they are not restricted to the local namespace of the
         ingredient.
         """

--- a/sacred/initialize.py
+++ b/sacred/initialize.py
@@ -113,7 +113,6 @@ class Scaffold(object):
             cfg_upup = ch(deepcopy(config), command_name, logger)
             if cfg_upup:
                 recursive_update(final_cfg_updates, cfg_upup)
-        recursive_update(final_cfg_updates, self.config_updates)
         return final_cfg_updates
 
     def get_config_modifications(self):

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -277,16 +277,19 @@ def test_config_hook_updates_config(ex):
 
     @ex.config
     def cfg():
-        a = 'hello'
+        a = 'before the hook'
 
     @ex.config_hook
     def hook(config, command_name, logger):
-        config.update({'a': 'me'})
-        return config
+        # Return a dictionary of updates
+        return {'a': config['a'].replace('before', 'after')}
 
     @ex.main
     def foo():
         pass
 
     r = ex.run()
-    assert r.config['a'] == 'me'
+    assert r.config['a'] == 'after the hook'
+
+    r = ex.run(config_updates={'a': 'talk before you think'})
+    assert r.config['a'] == 'talk after you think'


### PR DESCRIPTION
The updates contained in the return dictionary of a `config_hook` were overwritten if a corresponding
entry existed in `config_updates` as passed e.g. from the command line. This commit removes the line
that is responsible for this behavior, as well as adding a test case and a slightly modified documentation.