### PR TITLE
Enable travis CI build on all branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,3 @@ matrix:
     env: TOX_ENV=coverage
 script:
   - tox -e $TOX_ENV
-
-branches:
-  only:
-    - master
-    - /^release.*$/


### PR DESCRIPTION
When managing a fork, it's quite helpful to have travis CI run test on every commit on all branches. It allows contributors who whishes to make use of travis to check their work before doing a pull request.

Was there any idea/rationale behind excluding all dev branches from travis?