### PR TITLE
Removing MissingDependencyMock

### DIFF
--- a/sacred/optional.py
+++ b/sacred/optional.py
@@ -5,25 +5,6 @@ import importlib
 from sacred.utils import modules_exist
 
 
-class MissingDependencyMock(object):
-    def __init__(self, depends_on):
-        self.depends_on = depends_on
-
-    def __getattribute__(self, item):
-        dep = object.__getattribute__(self, 'depends_on')
-        if isinstance(dep, (list, tuple)):
-            raise ImportError('Depends on missing {!r} packages.'.format(dep))
-        else:
-            raise ImportError('Depends on missing {!r} package.'.format(dep))
-
-    def __call__(self, *args, **kwargs):
-        dep = object.__getattribute__(self, 'depends_on')
-        if isinstance(dep, (list, tuple)):
-            raise ImportError('Depends on missing {!r} packages.'.format(dep))
-        else:
-            raise ImportError('Depends on missing {!r} package.'.format(dep))
-
-
 def optional_import(*package_names):
     try:
         packages = [importlib.import_module(pn) for pn in package_names]

--- a/tests/test_optional.py
+++ b/tests/test_optional.py
@@ -3,21 +3,7 @@
 from __future__ import division, print_function, unicode_literals
 
 import pytest
-from sacred.optional import MissingDependencyMock, optional_import
-
-
-def test_missing_dependency_mock_raises_on_access():
-    MongoObserver = MissingDependencyMock('pymongo')
-    with pytest.raises(ImportError) as e:
-        MongoObserver.create(db_name='db_name', url='url')
-    assert 'pymongo' in e.value.args[0]
-
-
-def test_missing_dependency_mock_raises_on_call():
-    MongoObserver = MissingDependencyMock('pymongo')
-    with pytest.raises(ImportError) as e:
-        MongoObserver('some', params='passed')
-    assert 'pymongo' in e.value.args[0]
+from sacred.optional import optional_import
 
 
 def test_optional_import():


### PR DESCRIPTION
This class is unused since 216549ca325439013b7f9225346facd074ee3a82 . 

If needed again, we should pull it out of git. Leaving it master is not useful at the moment.