### PR TITLE
Fix for automatic seeding with tensorflow 2

### DIFF
--- a/sacred/randomness.py
+++ b/sacred/randomness.py
@@ -31,7 +31,11 @@ def set_global_seed(seed):
         opt.np.random.seed(seed)
     if module_is_in_cache('tensorflow'):
         import tensorflow as tf
-        tf.set_random_seed(seed)
+        from packaging import version
+        if version.parse(tf.__version__) < version.parse('2.0.0a0'):
+            tf.set_random_seed(seed)
+        else:
+            tf.random.set_seed(seed)
     if module_is_in_cache('torch'):
         import torch
         torch.manual_seed(seed)


### PR DESCRIPTION
I didn't find a way to add a test for this on travis. Installing tensorflow 2 in a new build just for that seems overkill. 

I tested locally, if we add more stuff depending on tensorflow 2 in the future, it might worth it to add a new build to travis.

packaging.version.parse is a third-party utility but is used by setuptools. To avoid having users running into a failed import, I added the import in the `if` section.

Related issue: #445