### PR TITLE
Fixed #445: Incompatibility with `tensorflow-gpu`

### DIFF
--- a/sacred/utils.py
+++ b/sacred/utils.py
@@ -8,7 +8,6 @@ import inspect
 import logging
 import os.path
 import pkgutil
-import pkg_resources
 import re
 import shlex
 import sys
@@ -677,15 +676,15 @@ def module_is_imported(modname, scope=None):
     return False
 
 
-def get_package_version(dist_name):
-    """Returns a parsed version string of a package."""
-    version_string = pkg_resources.get_distribution(dist_name).version
-    return version.parse(version_string)
-
-
 def parse_version(version_string):
     """Returns a parsed version string."""
     return version.parse(version_string)
+
+
+def get_package_version(name):
+    """Returns a parsed version string of a package."""
+    version_string = __import__(name).__version__
+    return parse_version(version_string)
 
 
 def ensure_wellformed_argv(argv):

--- a/sacred/utils.py
+++ b/sacred/utils.py
@@ -4,6 +4,7 @@ from __future__ import division, print_function, unicode_literals
 
 import collections
 import contextlib
+import importlib
 import inspect
 import logging
 import os.path
@@ -683,7 +684,7 @@ def parse_version(version_string):
 
 def get_package_version(name):
     """Returns a parsed version string of a package."""
-    version_string = __import__(name).__version__
+    version_string = importlib.import_module(name).__version__
     return parse_version(version_string)
 
 


### PR DESCRIPTION
**Problem:**
Failing to read the version of import package `tensorflow` if distribution package `tensorflow-gpu` was installed.

**Cause:**
The version of the distribution package was retrieved rather than the version of the import package.

**Solution:**
Solving by actually importing the package and retrieving the version string.