### PR TITLE
Suggestion: MD5-hashed config for duplication checking

### DIFF
--- a/sacred/commandline_options.py
+++ b/sacred/commandline_options.py
@@ -334,7 +334,7 @@ class CaptureOption(CommandLineOption):
 
 class MD5Option(CommandLineOption):
     """Controls whether an MD5 hash of the used configuration is stored."""
-    
+
     short_flag = 'md5'
 
     @classmethod
@@ -344,7 +344,7 @@ class MD5Option(CommandLineOption):
 
 class MD5IgnoreOption(CommandLineOption):
     """Sets list of parameters ignored during hash calculation."""
-    
+
     short_flag = 'md5_ignore'
     arg = 'MD5_IGNORED'
     arg_description = 'Comma-separated list of parameters ignored during hash calculation.'

--- a/sacred/commandline_options.py
+++ b/sacred/commandline_options.py
@@ -331,3 +331,25 @@ class CaptureOption(CommandLineOption):
     @classmethod
     def apply(cls, args, run):
         run.capture_mode = args
+
+class MD5Option(CommandLineOption):
+    """Controls whether an MD5 hash of the used configuration is stored."""
+    
+    short_flag = 'md5'
+
+    @classmethod
+    def apply(cls, args, run):
+        run._md5_enabled = True
+
+
+class MD5IgnoreOption(CommandLineOption):
+    """Sets list of parameters ignored during hash calculation."""
+    
+    short_flag = 'md5_ignore'
+    arg = 'MD5_IGNORED'
+    arg_description = 'Comma-separated list of parameters ignored during hash calculation.'
+
+    @classmethod
+    def apply(cls, args, run):
+        """Set comma-separated ignored parameters for hash calculation."""
+        run._md5_ignored = args.split(',')

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -470,7 +470,7 @@ class Experiment(Ingredient):
 
         if run._md5_enabled:
             run.meta_info['md5'], run.meta_info['md5_ignored'] = \
-                self._compute_md5(run.config, run._md5_ignored)
+                self._compute_md5(run.experiment_info, run.config, run._md5_ignored)
 
         self.current_run = run
         return run
@@ -497,7 +497,7 @@ class Experiment(Ingredient):
                 return True
         return False
 
-    def _compute_md5(self, config, ignored_parameters):
+    def _compute_md5(self, info, config, ignored_parameters):
         actually_ignored = []
         if not ignored_parameters is None:
             config = config.copy()
@@ -506,5 +506,5 @@ class Experiment(Ingredient):
                     del config[param]
                     actually_ignored.append(param)
         return hashlib.md5(
-            json.dumps(config, separators = (',', ':'), sort_keys = True)\
+            json.dumps((info, config), separators = (',', ':'), sort_keys = True)\
                 .encode('utf-8')).hexdigest(), tuple(actually_ignored)

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -25,8 +25,7 @@ from sacred.initialize import create_run
 from sacred.utils import print_filtered_stacktrace, ensure_wellformed_argv, \
     SacredError, format_sacred_error
 
-__all__ = ('Experiment', 'NoDuplicateExperiment', 'DuplicateError', )
-
+__all__ = ('Experiment', )
 
 class Experiment(Ingredient):
     """
@@ -506,6 +505,6 @@ class Experiment(Ingredient):
                 if param in config:
                     del config[param]
                     actually_ignored.append(param)
-        return hashlib.sha1(
+        return hashlib.md5(
             json.dumps(config, separators = (',', ':'), sort_keys = True)\
                 .encode('utf-8')).hexdigest(), tuple(actually_ignored)

--- a/sacred/no_duplicate_experiment.py
+++ b/sacred/no_duplicate_experiment.py
@@ -9,7 +9,7 @@ __all__ = ('DuplicateChecker', 'DuplicateCheckerMongo', 'DuplicateError',
   'NoDuplicateExperiment', )
 
 class DuplicateError(RuntimeError):
-  def __init__(*args, **kwargs):
+  def __init__(self, *args, **kwargs):
     self.info = None
 
 class NoDuplicateExperiment(Experiment):

--- a/sacred/no_duplicate_experiment.py
+++ b/sacred/no_duplicate_experiment.py
@@ -1,0 +1,50 @@
+from sacred.experiment import Experiment
+
+class DuplicateError(Exception):
+  def set_info(self, info):
+    self.info = info
+
+class NoDuplicateExperiment(Experiment):
+  def __init__(self, *args, duplicate_checker = None, ignored_params = None, **kwargs):
+    super().__init__(*args, **kwargs)
+    self._duplicate_checker = duplicate_checker
+    self._ignored_params = ignored_params
+    self.pre_run_hook(
+      lambda run, logger:
+        self._prerun_hook_check_duplicate(run, logger))
+    self.option_hook(lambda options: self._option_hook_add_md5(options))
+  
+  def _option_hook_add_md5(self, options):
+    options['--md5'] = True
+    if not self._ignored_params is None:
+      options['--md5_ignore'] = ','.join(self._ignored_params)
+
+  def _prerun_hook_check_duplicate(self, run, logger):
+    if self._duplicate_checker is None:
+      logger.warning('empty duplicate checker, cannot check for duplicates!')
+      return
+    exception = DuplicateError()
+    dupe = self._duplicate_checker.check_duplicate(run, logger, exception)
+    if dupe > -1:
+      exception.args = ('Experiment already run, id={:d}!'.format(dupe), )
+      raise exception
+
+class DuplicateChecker(object):
+  def check_duplicate(run, logger, exception):
+    return -1
+
+class DuplicateCheckerMongo(DuplicateChecker):
+  def __init__(self, host, port, collection, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    from pymongo import MongoClient
+    self.client = MongoClient(host, port)
+    self.collection = self.client[collection]
+
+  def check_duplicate(self, run, logger, exception):
+    runs = tuple(self.collection.runs.find({'meta.md5': run.meta_info['md5']}))
+    if len(runs) > 0:
+      exception.set_info(runs)
+      found = runs[-1]['_id']
+    else:
+      found = -1
+    return found


### PR DESCRIPTION
Hi, I have implemented duplication checking of Experiments in a new class called `NoDuplicateExperiment`. For this I had to add MD5 computation capabilities. Just as an inspiration..

Example usage:

```
from sacred.no_duplicate_experiment import NoDuplicateExperiment, DuplicateCheckerMongo
from sacred.observers import MongoObserver

MONGO_HOST = 'localhost'
MONGO_PORT = 27017
MONGO_DB = 'sacred'

exp = NoDuplicateExperiment('test',
  duplicate_checker = DuplicateCheckerMongo(MONGO_HOST, MONGO_PORT, MONGO_DB),
  ignored_params = ('parameter2', ))
exp.observers.append(
  MongoObserver.create(url = '{}:{}'.format(MONGO_HOST, MONGO_PORT), db_name = MONGO_DB))

@exp.config
def config():
  parameter1 = 1
  parameter2 = 'ignored'

@exp.automain
def run(parameter1, parameter2):
  return parameter1 + 1
```