### PR TITLE
FileObserver setup concurrent-safe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ matrix:
     env: TOX_ENV=tensorflow-2
   - python: "3.6"
     env: TOX_ENV=flake8
-  - python: "2.7"
-    env: TOX_ENV=coverage
   - python: "3.5"
     env: TOX_ENV=coverage
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
     env: TOX_ENV=tensorflow-2
   - python: "3.6"
     env: TOX_ENV=flake8
+  - python: "2.7"
+    env: TOX_ENV=coverage
   - python: "3.5"
     env: TOX_ENV=coverage
 script:

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -10,7 +10,7 @@ from shutil import copyfile
 from sacred.commandline_options import CommandLineOption
 from sacred.dependencies import get_digest
 from sacred.observers.base import RunObserver
-from sacred.utils import FileNotFoundError, FileExistsError  # py2 compat.
+from sacred.utils import FileNotFoundError, FileExistsError  # py2 compat. pylint: disable=redefined-builtin
 from sacred import optional as opt
 from sacred.serializer import flatten
 
@@ -66,10 +66,10 @@ class FileStorageObserver(RunObserver):
                    if os.path.isdir(os.path.join(self.basedir, d)) and
                    d.isdigit()]
         _id = max(dir_nrs + [0]) + 1
-        dir = os.path.join(self.basedir, str(_id))
+        new_dir = os.path.join(self.basedir, str(_id))
         try:
-            os.mkdir(dir)
-            self.dir = dir
+            os.mkdir(new_dir)
+            self.dir = new_dir
         except FileExistsError:  # Catch race conditions
             if raise_error:
                 # After some tries,

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -103,7 +103,7 @@ class FileStorageObserver(RunObserver):
             # assert m == md5sum
             source_info.append([s, os.path.relpath(store_path, self.basedir)])
         return source_info
-           
+
     def started_event(self, ex_info, command, host_info, start_time, config,
                       meta_info, _id):
         self._make_run_dir(_id)

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -103,8 +103,7 @@ class FileStorageObserver(RunObserver):
             # assert m == md5sum
             source_info.append([s, os.path.relpath(store_path, self.basedir)])
         return source_info
-
-                  
+           
     def started_event(self, ex_info, command, host_info, start_time, config,
                       meta_info, _id):
         self._make_run_dir(_id)

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -68,7 +68,7 @@ class FileStorageObserver(RunObserver):
                 dir_nrs = [int(d) for d in os.listdir(self.basedir)
                            if os.path.isdir(os.path.join(self.basedir, d)) and
                            d.isdigit()]
-                _id = max(dir_nrs + [0]) + 1
+                _id = max(*dir_nrs, 0) + 1
                 self.dir = os.path.join(self.basedir, str(_id))
                 try:
                     os.mkdir(self.dir)

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -4,7 +4,6 @@ from __future__ import division, print_function, unicode_literals
 import json
 import os
 import os.path
-import tempfile
 
 from shutil import copyfile
 
@@ -50,7 +49,7 @@ class FileStorageObserver(RunObserver):
         self.info = None
         self.cout = ""
         self.cout_write_cursor = 0
-    
+
     def _make_run_dir(self, _id):
         os.makedirs(self.basedir, exist_ok=True)
         if _id is None:
@@ -71,7 +70,7 @@ class FileStorageObserver(RunObserver):
         else:
             self.dir = os.path.join(self.basedir, str(_id))
             os.mkdir(self.dir)
-            
+
     def queued_event(self, ex_info, command, host_info, queue_time, config,
                      meta_info, _id):
         self._make_run_dir(_id)

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -10,9 +10,11 @@ from shutil import copyfile
 from sacred.commandline_options import CommandLineOption
 from sacred.dependencies import get_digest
 from sacred.observers.base import RunObserver
-from sacred.utils import FileNotFoundError, FileExistsError  # py2 compat. pylint: disable=redefined-builtin
 from sacred import optional as opt
 from sacred.serializer import flatten
+# pylint: disable=redefined-builtin
+from sacred.utils import FileNotFoundError, FileExistsError  # py2 compat.
+# pylint: enable=redefined-builtin
 
 
 DEFAULT_FILE_STORAGE_PRIORITY = 20

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -53,8 +53,7 @@ class FileStorageObserver(RunObserver):
 
     def queued_event(self, ex_info, command, host_info, queue_time, config,
                      meta_info, _id):
-        if not os.path.exists(self.basedir):
-            os.makedirs(self.basedir)
+        os.makedirs(self.basedir, exist_ok=True)
         if _id is None:
             self.dir = tempfile.mkdtemp(prefix='run_', dir=self.basedir)
         else:
@@ -91,8 +90,7 @@ class FileStorageObserver(RunObserver):
 
     def started_event(self, ex_info, command, host_info, start_time, config,
                       meta_info, _id):
-        if not os.path.exists(self.basedir):
-            os.makedirs(self.basedir)
+        os.makedirs(self.basedir, exist_ok=True)
         if _id is None:
             for i in range(200):
                 dir_nrs = [int(d) for d in os.listdir(self.basedir)
@@ -137,8 +135,7 @@ class FileStorageObserver(RunObserver):
         return os.path.relpath(self.dir, self.basedir) if _id is None else _id
 
     def find_or_save(self, filename, store_dir):
-        if not os.path.exists(store_dir):
-            os.makedirs(store_dir)
+        os.makedirs(store_dir, exist_ok=True)
         source_name, ext = os.path.splitext(os.path.basename(filename))
         md5sum = get_digest(filename)
         store_name = source_name + '_' + md5sum + ext

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -58,7 +58,7 @@ class FileStorageObserver(RunObserver):
         try:
             os.makedirs(name, mode, exist_ok)
         except TypeError:
-            if os.path.exists(name):
+            if not os.path.exists(name):
                 os.makedirs(name, mode)
 
     def _make_run_dir(self, _id):

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -50,8 +50,19 @@ class FileStorageObserver(RunObserver):
         self.cout = ""
         self.cout_write_cursor = 0
 
+    @staticmethod
+    def _makedirs(name, mode=0o777, exist_ok=False):
+        """ Wrapper of os.makedirs with fallback
+            for exist_ok on python 2.
+        """
+        try:
+            os.makedirs(name, mode, exist_ok)
+        except TypeError:
+            if os.path.exists(name):
+                os.makedirs(name, mode)
+
     def _make_run_dir(self, _id):
-        os.makedirs(self.basedir, exist_ok=True)
+        self._makedirs(self.basedir, exist_ok=True)
         if _id is None:
             for i in range(200):
                 dir_nrs = [int(d) for d in os.listdir(self.basedir)
@@ -132,7 +143,7 @@ class FileStorageObserver(RunObserver):
         return os.path.relpath(self.dir, self.basedir) if _id is None else _id
 
     def find_or_save(self, filename, store_dir):
-        os.makedirs(store_dir, exist_ok=True)
+        self._makedirs(store_dir, exist_ok=True)
         source_name, ext = os.path.splitext(os.path.basename(filename))
         md5sum = get_digest(filename)
         store_name = source_name + '_' + md5sum + ext

--- a/tests/test_observers/test_file_storage_observer.py
+++ b/tests/test_observers/test_file_storage_observer.py
@@ -8,6 +8,7 @@ import tempfile
 from copy import copy
 import pytest
 import json
+from unittest.mock import patch
 
 from sacred.observers.file_storage import FileStorageObserver
 from sacred.serializer import restore
@@ -114,6 +115,14 @@ def test_fs_observer_started_event_creates_rundir(dir_obs, sample_run):
         "artifacts": [],
         "status": "RUNNING"
     }
+
+    def mkdir_raises_file_exists(name):
+        raise FileExistsError
+
+    with pytest.raises(FileExistsError):
+        with patch('os.mkdir', mkdir_raises_file_exists):
+            sample_run['_id'] = None
+            _id = obs.started_event(**sample_run)
 
 
 def test_fs_observer_started_event_stores_source(dir_obs, sample_run, tmpfile):

--- a/tests/test_observers/test_file_storage_observer.py
+++ b/tests/test_observers/test_file_storage_observer.py
@@ -10,8 +10,10 @@ import pytest
 import json
 
 from sacred.observers.file_storage import FileStorageObserver
-from sacred.utils import FileExistsError  # py2 compat. pylint: disable=redefined-builtin
 from sacred.metrics_logger import ScalarMetricLogEntry, linearize_metrics
+# pylint: disable=redefined-builtin
+from sacred.utils import FileExistsError  # py2 compat.
+# pylint: enable=redefined-builtin
 
 
 T1 = datetime.datetime(1999, 5, 4, 3, 2, 1, 0)

--- a/tests/test_observers/test_file_storage_observer.py
+++ b/tests/test_observers/test_file_storage_observer.py
@@ -10,6 +10,7 @@ import pytest
 import json
 
 from sacred.observers.file_storage import FileStorageObserver
+from sacred.utils import FileExistsError  # py2 compat.
 from sacred.metrics_logger import ScalarMetricLogEntry, linearize_metrics
 
 

--- a/tests/test_observers/test_file_storage_observer.py
+++ b/tests/test_observers/test_file_storage_observer.py
@@ -116,7 +116,7 @@ def test_fs_observer_started_event_creates_rundir(dir_obs, sample_run, monkeypat
     }
 
     def mkdir_raises_file_exists(name):
-        raise FileExistsError
+        raise FileExistsError("File already exists: " + name)
 
     with monkeypatch.context() as m:
         m.setattr('os.mkdir', mkdir_raises_file_exists)

--- a/tests/test_observers/test_file_storage_observer.py
+++ b/tests/test_observers/test_file_storage_observer.py
@@ -8,7 +8,10 @@ import tempfile
 from copy import copy
 import pytest
 import json
-from unittest.mock import patch
+try:  # unittest.mock requires python >=3.3
+    from unittest import mock
+except ImportError:
+    mock = None
 
 from sacred.observers.file_storage import FileStorageObserver
 from sacred.serializer import restore
@@ -119,10 +122,12 @@ def test_fs_observer_started_event_creates_rundir(dir_obs, sample_run):
     def mkdir_raises_file_exists(name):
         raise FileExistsError
 
-    with pytest.raises(FileExistsError):
-        with patch('os.mkdir', mkdir_raises_file_exists):
-            sample_run['_id'] = None
-            _id = obs.started_event(**sample_run)
+    # unittest.mock requires python >=3.3
+    if mock is not None:
+        with pytest.raises(FileExistsError):
+            with mock.patch('os.mkdir', mkdir_raises_file_exists):
+                sample_run['_id'] = None
+                _id = obs.started_event(**sample_run)
 
 
 def test_fs_observer_started_event_stores_source(dir_obs, sample_run, tmpfile):

--- a/tests/test_observers/test_file_storage_observer.py
+++ b/tests/test_observers/test_file_storage_observer.py
@@ -10,7 +10,7 @@ import pytest
 import json
 
 from sacred.observers.file_storage import FileStorageObserver
-from sacred.utils import FileExistsError  # py2 compat.
+from sacred.utils import FileExistsError  # py2 compat. pylint: disable=redefined-builtin
 from sacred.metrics_logger import ScalarMetricLogEntry, linearize_metrics
 
 


### PR DESCRIPTION
The FileStorage observer usually works great for me in concurrent environments (e.g. 50 nodes writing simultaneous). Only at the very first runs, some die with an exception because they try to create the storage directories simultaneously. This PR tries to fix this by the following changes:

* Use os.makedirs with exists_ok=True flag (available for python >= 3.2)
* Add queued runs the same way than started runs