### PR TITLE
Add started_text to config options for telegram observer

### DIFF
--- a/sacred/observers/telegram_obs.py
+++ b/sacred/observers/telegram_obs.py
@@ -76,8 +76,8 @@ class TelegramObserver(RunObserver):
         The file can be in any format supported by Sacred
         (.json, .pickle, [.yaml]).
         It has to specify a ``token`` and a ``chat_id`` and can optionally set
-        ``silent_completion``,``completed_text``, ``interrupted_text``, and
-        ``failed_text``.
+        ``silent_completion``, ``started_text``, ``completed_text``,
+        ``interrupted_text``, and ``failed_text``.
         """
         import telegram
         d = load_config_file(filename)
@@ -89,7 +89,8 @@ class TelegramObserver(RunObserver):
         else:
             raise ValueError("Telegram configuration file must contain "
                              "entries for 'token' and 'chat_id'!")
-        for k in ['completed_text', 'interrupted_text', 'failed_text']:
+        for k in ['started_text', 'completed_text', 'interrupted_text',
+                  'failed_text']:
             if k in d:
                 setattr(obs, k, d[k])
         return obs


### PR DESCRIPTION
Currently it is not possible to customize the `started_text` of a telegram observer using the config file.

It seems to me that it was just missing in the set of config properties that are updated. This fixes the problem for me.

If there is a good reason for not allowing this, feel free to disregard my change. However, if this is the case it would probably be helpful to add a comment explaining the behavior.