### PR TITLE
Bug-fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,10 @@ munch>=2.0.4
 pbr>=1.10.0
 py>=1.4.32
 py-cpuinfo>=4.0
-pytest>=3.0.5
 six>=1.10.0
 wrapt>=1.10.8
 packaging>=18.0
 pymongo>=3.8.0
+
+# tests/test_utils.py depends on that pytest version is exactly 4.3.0
+pytest==4.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pytest>=3.0.5
 six>=1.10.0
 wrapt>=1.10.8
 packaging>=18.0
+pymongo>=3.8.0

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -242,10 +242,10 @@ class Experiment(Ingredient):
         if not args['help'] and err:
             print(short_usage)
             print(err)
-            exit(1)
+            sys.exit(1)
 
         if self._handle_help(args, usage):
-            exit()
+            sys.exit()
 
         try:
             return self.run(cmd_name, config_updates, named_configs, {}, args)
@@ -276,7 +276,7 @@ class Experiment(Ingredient):
                     print(format_sacred_error(e, short_usage), file=sys.stderr)
                 else:
                     print_filtered_stacktrace()
-                exit(1)
+                sys.exit(1)
 
     def open_resource(self, filename, mode='r'):
         """Open a file and also save it as a resource.

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setup(
         'wrapt>=1.0, <2.0',
         'py-cpuinfo>=4.0',
         'colorama>=0.4',
-        'packaging>=18.0'
+        'packaging>=18.0',
+        'pymongo>=3.8.0'
     ],
     tests_require=[
         'mock>=0.8, <3.0',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     ],
     tests_require=[
         'mock>=0.8, <3.0',
-        'pytest>=3.0.1, <4.0'],
+        'pytest==4.3.0'],
 
     classifiers=list(filter(None, classifiers.split('\n'))),
     description='Facilitates automated and reproducible experimental research',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,12 @@ import os.path
 import re
 import shlex
 import sys
+import warnings
 from imp import reload
 
 from sacred.settings import SETTINGS
 
-EXAMPLES_PATH = os.path.abspath('examples')
+EXAMPLES_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'examples')
 BLOCK_START = re.compile('^\s\s+\$.*$', flags=re.MULTILINE)
 
 
@@ -50,7 +51,11 @@ def pytest_generate_tests(metafunc):
         example_tests = []
         example_ids = []
         for example_name in sorted(examples):
-            example = __import__(example_name)
+            try:
+                example = __import__(example_name)
+            except ModuleNotFoundError:
+                warnings.warn('could not import {name}, skips during test.'.format(name=example_name))
+                continue
             calls_outs = get_calls_from_doc(example.__doc__)
             for i, (call, out) in enumerate(calls_outs):
                 example = reload(example)

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -11,8 +11,12 @@ from sacred.dependencies import (PEP440_VERSION_PATTERN, PackageDependency,
                                  is_local_source)
 import sacred.optional as opt
 
-EXAMPLE_SOURCE = 'tests/__init__.py'
-EXAMPLE_DIGEST = '9e428c0aa58b75ff150c4f625e32af68'
+TEST_DIRECTORY = os.path.dirname(__file__)
+EXAMPLE_SOURCE = os.path.join(TEST_DIRECTORY, '__init__.py')
+
+# The digest below is calculated from the test/__init__.py with only Python shebang and coding-information.
+# This type of hard-coding is most probably a quite bad idea.
+EXAMPLE_DIGEST = '0ce83bfac9c94fe637760c887921e269'
 
 
 @pytest.mark.parametrize('version', [
@@ -138,12 +142,12 @@ def test_gather_sources_and_dependencies():
     assert isinstance(main, Source)
     assert isinstance(sources, set)
     assert isinstance(deps, set)
-    assert main == Source.create('tests/dependency_example.py')
+    assert main == Source.create(os.path.join(TEST_DIRECTORY, 'dependency_example.py'))
     expected_sources = {
-        Source.create('tests/__init__.py'),
-        Source.create('tests/dependency_example.py'),
-        Source.create('tests/foo/__init__.py'),
-        Source.create('tests/foo/bar.py')
+        Source.create(os.path.join(TEST_DIRECTORY, '__init__.py')),
+        Source.create(os.path.join(TEST_DIRECTORY, 'dependency_example.py')),
+        Source.create(os.path.join(TEST_DIRECTORY, 'foo', '__init__.py')),
+        Source.create(os.path.join(TEST_DIRECTORY, 'foo', 'bar.py'))
     }
     assert sources == expected_sources
 
@@ -160,18 +164,17 @@ def test_gather_sources_and_dependencies():
 
 def test_custom_base_dir():
     from tests.basedir.my_experiment import some_func
-    base_dir = os.path.abspath('tests')
-    main, sources, deps = gather_sources_and_dependencies(some_func.__globals__, base_dir)
+    main, sources, deps = gather_sources_and_dependencies(some_func.__globals__, TEST_DIRECTORY)
     assert isinstance(main, Source)
     assert isinstance(sources, set)
     assert isinstance(deps, set)
-    assert main == Source.create('tests/basedir/my_experiment.py')
+    assert main == Source.create(os.path.join(TEST_DIRECTORY, 'basedir', 'my_experiment.py'))
     expected_sources = {
-        Source.create('tests/__init__.py'),
-        Source.create('tests/basedir/__init__.py'),
-        Source.create('tests/basedir/my_experiment.py'),
-        Source.create('tests/foo/__init__.py'),
-        Source.create('tests/foo/bar.py')
+        Source.create(os.path.join(TEST_DIRECTORY, '__init__.py')),
+        Source.create(os.path.join(TEST_DIRECTORY, 'basedir', '__init__.py')),
+        Source.create(os.path.join(TEST_DIRECTORY, 'basedir', 'my_experiment.py')),
+        Source.create(os.path.join(TEST_DIRECTORY, 'foo', '__init__.py')),
+        Source.create(os.path.join(TEST_DIRECTORY, 'foo', 'bar.py'))
     }
     assert sources == expected_sources
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -16,7 +16,7 @@ EXAMPLE_SOURCE = os.path.join(TEST_DIRECTORY, '__init__.py')
 
 # The digest below is calculated from the test/__init__.py with only Python shebang and coding-information.
 # This type of hard-coding is most probably a quite bad idea.
-EXAMPLE_DIGEST = '0ce83bfac9c94fe637760c887921e269'
+EXAMPLE_DIGEST = '9e428c0aa58b75ff150c4f625e32af68'
 
 
 @pytest.mark.parametrize('version', [


### PR DESCRIPTION
Fixes #495 by specifying pytest-version that is hard-coded in tests.
Fixes #491 by adding pymongo dependency.
Fixes error on running experiment on command-line by replacing `exit()` by `sys.exit`. `exit()` is intended for interactive runs.
Also fixes a number of broken tests.