### PR TITLE
Avoid file-observer fail to make run-dir for wrong listdir results

### DIFF
--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -67,7 +67,7 @@ class FileStorageObserver(RunObserver):
                 try:
                     self._make_next_dir()
                 except FileExistsError:  # Catch race conditions
-                    if fail_count < 100:
+                    if fail_count < 10000:
                         fail_count += 1
                     else:  # expect that something else went wrong
                         raise

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -73,8 +73,8 @@ class FileStorageObserver(RunObserver):
                     if fail_count < 1000:
                         fail_count += 1
                         # Random sleeps to break symmetry.
-                        # Logarithmic increase of expectation 0ms, 15ms, 24ms, ..., 150ms.
-                        # Final fail after average 2.1 minutes, maximum 4.3 minutes.
+                        # Logarithmic increase expectation 0ms, 15ms, ..., 150ms
+                        # Final fail after average 2.1 minutes, maximum 4.3
                         sleep(random() * log10(fail_count) / 10)
                     else:  # expect that something else went wrong
                         raise

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -4,9 +4,6 @@
 import json
 import os
 import os.path
-from time import sleep
-from random import random
-from math import log10
 
 from shutil import copyfile
 

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -73,7 +73,7 @@ class FileStorageObserver(RunObserver):
                     if fail_count < 1000:
                         fail_count += 1
                         # Random sleeps to break symmetry.
-                        # Logarithmic increase expectation 0ms, 15ms, ..., 150ms
+                        # Logarithmic increase expectation 0ms,15ms,...,150ms
                         # Final fail after average 2.1 minutes, maximum 4.3
                         sleep(random() * log10(fail_count) / 10)
                     else:  # expect that something else went wrong

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -53,10 +53,10 @@ class FileStorageObserver(RunObserver):
         dir_nrs = [int(d) for d in os.listdir(self.basedir)
                    if os.path.isdir(os.path.join(self.basedir, d)) and
                    d.isdigit()]
-        if len(dir_nrs) == 0:
-            return 0
-        else:
+        if dir_nrs:
             return max(dir_nrs)
+        else:
+            return 0
 
     def _make_dir(self, _id):
         new_dir = os.path.join(self.basedir, str(_id))

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -52,11 +52,16 @@ class FileStorageObserver(RunObserver):
         self.cout = ""
         self.cout_write_cursor = 0
 
-    def _make_next_dir(self):
+    def _maximum_existing_run_id(self):
         dir_nrs = [int(d) for d in os.listdir(self.basedir)
                    if os.path.isdir(os.path.join(self.basedir, d)) and
                    d.isdigit()]
-        _id = max(dir_nrs + [0]) + 1
+        if len(dir_nrs) == 0:
+            return 0
+        else:
+            return max(dir_nrs)
+
+    def _make_dir(self, _id):
         new_dir = os.path.join(self.basedir, str(_id))
         os.mkdir(new_dir)
         self.dir = new_dir  # set only if mkdir is successful
@@ -66,16 +71,14 @@ class FileStorageObserver(RunObserver):
         self.dir = None
         if _id is None:
             fail_count = 0
+            _id = self._maximum_existing_run_id() + 1
             while self.dir is None:
                 try:
-                    self._make_next_dir()
+                    self._make_dir(_id)
                 except FileExistsError:  # Catch race conditions
                     if fail_count < 1000:
                         fail_count += 1
-                        # Random sleeps to break symmetry.
-                        # Logarithmic increase expectation 0ms,15ms,...,150ms
-                        # Final fail after average 2.1 minutes, maximum 4.3
-                        sleep(random() * log10(fail_count) / 10)
+                        _id += 1
                     else:  # expect that something else went wrong
                         raise
         else:

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -4,6 +4,9 @@
 import json
 import os
 import os.path
+from time import sleep
+from random import random
+from math import log10
 
 from shutil import copyfile
 
@@ -67,8 +70,12 @@ class FileStorageObserver(RunObserver):
                 try:
                     self._make_next_dir()
                 except FileExistsError:  # Catch race conditions
-                    if fail_count < 10000:
+                    if fail_count < 1000:
                         fail_count += 1
+                        # Random sleeps to break symmetry.
+                        # Logarithmic increase of expectation 0ms, 15ms, 24ms, ..., 150ms.
+                        # Final fail after average 2.1 minutes, maximum 4.3 minutes.
+                        sleep(random() * log10(fail_count) / 10)
                     else:  # expect that something else went wrong
                         raise
         else:

--- a/tests/test_observers/test_file_storage_observer.py
+++ b/tests/test_observers/test_file_storage_observer.py
@@ -126,10 +126,10 @@ def test_fs_observer_started_event_creates_rundir(dir_obs, sample_run, monkeypat
             obs.started_event(**sample_run)
 
     # Assume listdir doesn't show existing file (e.g. due to caching or delay of network storage)
-    assert os.listdir(basedir) == [_id]
+    assert os.listdir(str(basedir)) == [_id]
     with monkeypatch.context() as m:
         m.setattr('os.listdir', lambda __: [])
-        assert os.listdir(basedir) == []
+        assert os.listdir(str(basedir)) == []
         _id2 = obs.started_event(**sample_run)
         assert _id2 == '2'
 

--- a/tests/test_observers/test_file_storage_observer.py
+++ b/tests/test_observers/test_file_storage_observer.py
@@ -90,11 +90,10 @@ def test_fs_observer_queued_event_creates_rundir(dir_obs, sample_run):
     }
 
 
-def test_fs_observer_started_event_creates_rundir(dir_obs, sample_run, monkeypatch):
+def test_fs_observer_started_event_creates_rundir(dir_obs, sample_run):
     basedir, obs = dir_obs
     sample_run['_id'] = None
     _id = obs.started_event(**sample_run)
-    assert _id == '1'
     run_dir = basedir.join(str(_id))
     assert run_dir.exists()
     assert run_dir.join('cout.txt').exists()
@@ -114,24 +113,34 @@ def test_fs_observer_started_event_creates_rundir(dir_obs, sample_run, monkeypat
         "status": "RUNNING"
     }
 
-    def mkdir_raises_file_exists(name, mode=0o777):
-        raise FileExistsError("File already exists: " + name)
 
-    # Assume some problem with the filesystem exists
-    #     therefore run dir creation should stop after some tries
-    with monkeypatch.context() as m:
-        m.setattr('os.mkdir', mkdir_raises_file_exists)
-        with pytest.raises(FileExistsError):
-            sample_run['_id'] = None
-            obs.started_event(**sample_run)
-
-    # Assume listdir doesn't show existing file (e.g. due to caching or delay of network storage)
+def test_fs_observer_started_event_creates_rundir_with_filesystem_delay(dir_obs, sample_run, monkeypatch):
+    """ Assumes listdir doesn't show existing file (e.g. due to caching or delay of network storage) """
+    basedir, obs = dir_obs
+    sample_run['_id'] = None
+    _id = obs.started_event(**sample_run)
+    assert _id == '1'
     assert os.listdir(str(basedir)) == [_id]
     with monkeypatch.context() as m:
-        m.setattr('os.listdir', lambda __: [])
+        m.setattr('os.listdir', lambda _: [])
         assert os.listdir(str(basedir)) == []
         _id2 = obs.started_event(**sample_run)
         assert _id2 == '2'
+
+
+def test_fs_observer_started_event_raises_file_exists_error(dir_obs, sample_run, monkeypatch):
+    """ Assumes some problem with the filesystem exists
+    therefore run dir creation should stop after some re-tries
+    """
+    def mkdir_raises_file_exists(name, mode=0o777):
+        raise FileExistsError("File already exists: " + name)
+
+    basedir, obs = dir_obs
+    sample_run['_id'] = None
+    with monkeypatch.context() as m:
+        m.setattr('os.mkdir', mkdir_raises_file_exists)
+        with pytest.raises(FileExistsError):
+            obs.started_event(**sample_run)
 
 
 def test_fs_observer_started_event_stores_source(dir_obs, sample_run, tmpfile):


### PR DESCRIPTION
In practice about 1% of my runs failed on creating the run directory (10 to 50 parallel worker, network storage), because of too many attempts. 
This pull request contains two improvements, which may solve this issue for me and others:

* Increase allowed fails from 100 to 1000
* Sleep for a random timeinterval after fail to break symmetry between workers. Interval increases with number of fails. 

Anyhow I am by no means an expert on such concurrency issues. If any of you comes up with a better solution, I would be happy to adopt it. 