### PR TITLE
Add pickle support to ReadOnly{Dict,List}

### DIFF
--- a/sacred/config/custom_containers.py
+++ b/sacred/config/custom_containers.py
@@ -245,6 +245,7 @@ class ReadOnlyContainer:
             filter_traceback='always'
         )
 
+
 class ReadOnlyDict(collections.Mapping, ReadOnlyContainer):
     """
     A read-only variant of a `dict`
@@ -278,7 +279,7 @@ class ReadOnlyDict(collections.Mapping, ReadOnlyContainer):
     def __init__(self, *args, **kwargs):
         # Python 2.7 compatibility
         self.message = kwargs.pop('message', None) or \
-                       'This ReadOnlyDict is read-only!'
+            'This ReadOnlyDict is read-only!'
 
         # Call dict init
         self.container = dict(*args, **kwargs)


### PR DESCRIPTION
Closes #499.

Initially I tried to add `pickle` support using `__getstate__` and `__setstate`. However, `pickle`, seems to special-case built-in container types: my `__setstate__` method never even got called in `ReadOnlyDict`. Accordingly I decided to switch to a proxy style, where we are wrapping a dict/list object. This is similar to the [MappingProxyType](https://docs.python.org/3/library/types.html#types.MappingProxyType), which we could probably replace `ReadOnlyDict` with once Python 2.7 support is dropped (it's only available in Python 3.3+).