### PR TITLE
Handle missing brand key

### DIFF
--- a/sacred/host_info.py
+++ b/sacred/host_info.py
@@ -155,4 +155,7 @@ def _get_cpu_by_proc_cpuinfo():
 
 
 def _get_cpu_by_pycpuinfo():
-    return cpuinfo.get_cpu_info()['brand']
+    try:
+        return cpuinfo.get_cpu_info()['brand']
+    except:
+        return "Unknown"

--- a/sacred/host_info.py
+++ b/sacred/host_info.py
@@ -155,7 +155,4 @@ def _get_cpu_by_proc_cpuinfo():
 
 
 def _get_cpu_by_pycpuinfo():
-    try:
-        return cpuinfo.get_cpu_info()['brand']
-    except:
-        return "Unknown"
+    return cpuinfo.get_cpu_info().get('brand', 'Unknown')


### PR DESCRIPTION
On some machines the brand key may not be available, causing an unnecessary crash