### PR TITLE
Make pymongo optional again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
     env: TOX_ENV=tensorflow-1
   - python: "3.6"
     env: TOX_ENV=tensorflow-2
+  - python: "3.7"
+    env: TOX_ENV=setup
   - python: "3.6"
     env: TOX_ENV=flake8
   - python: "3.6"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,8 +13,7 @@ numpy==1.16.2
 packaging>=18.0
 pandas==0.24.2
 pbr==1.10.0
-py-cpuinfo==4.0
-pymongo==3.4.0
+# tests/test_utils.py depends on that pytest version is exactly 4.3.0
 pytest==4.3.0
 python-dateutil==2.6.0
 pytz==2016.10
@@ -27,3 +26,4 @@ tinydb==3.2.1
 tinydb-serialization==1.0.3
 wrapt==1.10.8
 scikit-learn==0.20.3
+pymongo==3.8.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -27,3 +27,5 @@ tinydb-serialization==1.0.3
 wrapt==1.10.8
 scikit-learn==0.20.3
 pymongo==3.8.0
+py-cpuinfo==4.0
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,5 @@ jsonpickle>=0.9.3
 mock>=2.0.0
 munch>=2.0.4
 pbr>=1.10.0
-py>=1.4.32
-py-cpuinfo>=4.0
-six>=1.10.0
 wrapt>=1.10.8
 packaging>=18.0
-pymongo>=3.8.0
-
-# tests/test_utils.py depends on that pytest version is exactly 4.3.0
-pytest==4.3.0

--- a/sacred/observers/mongo.py
+++ b/sacred/observers/mongo.py
@@ -9,10 +9,6 @@ import sys
 import time
 from tempfile import NamedTemporaryFile
 
-import pymongo
-import pymongo.errors
-import gridfs
-
 import sacred.optional as opt
 from sacred.commandline_options import CommandLineOption
 from sacred.dependencies import get_digest
@@ -56,6 +52,9 @@ def force_bson_encodeable(obj):
 
 
 class MongoObserver(RunObserver):
+    import pymongo
+    import pymongo.errors
+    import gridfs
     COLLECTION_NAME_BLACKLIST = {'fs.files', 'fs.chunks', '_properties',
                                  'system.indexes', 'search_space',
                                  'search_spaces'}
@@ -81,6 +80,8 @@ class MongoObserver(RunObserver):
         -------
         An instantiated MongoObserver.
         """
+        import pymongo
+        import gridfs
 
         if client is not None:
             if not isinstance(client, pymongo.MongoClient):
@@ -266,6 +267,8 @@ class MongoObserver(RunObserver):
                     .append({"name": key, "id": str(result.upserted_id)})
 
     def insert(self):
+        import pymongo.errors
+
         if self.overwrite:
             return self.save()
 
@@ -318,8 +321,7 @@ class MongoObserver(RunObserver):
                       "Most likely it is either the 'info' or the 'result'.",
                       file=sys.stderr)
 
-        if not os.path.exists(self.failure_dir):
-            os.makedirs(self.failure_dir)
+        os.makedirs(self.failure_dir, exist_ok=True)
         with NamedTemporaryFile(suffix='.pickle', delete=False,
                                 prefix='sacred_mongo_fail_{}_'.format(
                                     self.run_entry["_id"]
@@ -448,6 +450,7 @@ class QueueCompatibleMongoObserver(MongoObserver):
                 .append({"name": metric_name, "id": str(result.upserted_id)})
 
     def save(self):
+        import pymongo
         try:
             self.runs.update_one({'_id': self.run_entry['_id']},
                                  {'$set': self.run_entry})
@@ -456,6 +459,7 @@ class QueueCompatibleMongoObserver(MongoObserver):
                                 '(most likely in the info)')
 
     def final_save(self, attempts):
+        import pymongo
         try:
             self.runs.update_one({'_id': self.run_entry['_id']},
                                  {'$set': self.run_entry}, upsert=True)

--- a/sacred/observers/mongo.py
+++ b/sacred/observers/mongo.py
@@ -52,9 +52,6 @@ def force_bson_encodeable(obj):
 
 
 class MongoObserver(RunObserver):
-    import pymongo
-    import pymongo.errors
-    import gridfs
     COLLECTION_NAME_BLACKLIST = {'fs.files', 'fs.chunks', '_properties',
                                  'system.indexes', 'search_space',
                                  'search_spaces'}

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'py-cpuinfo>=4.0',
         'colorama>=0.4',
         'packaging>=18.0',
-        'pymongo>=3.8.0'
     ],
     tests_require=[
         'mock>=0.8, <3.0',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35, py36, py37, flake8, tensorflow-1, tensorflow-2
+envlist = py35, py36, py37, setup, flake8, tensorflow-1, tensorflow-2
 # py32 does not work because of the 'wrapt' dependency
 # py33 is not supported by newer versions of numpy
 # py34 is not supported by newer versions of pandas
@@ -34,10 +34,18 @@ commands =
     pytest tests/test_stflow \
         {posargs}
 
+[testenv:setup]
+basepython = python
+deps = 
+    pytest==4.3.0
+    mock==2.0.0
+commands = 
+    pytest --ignore=tests/test_observers \
+        {posargs} 
+
 [testenv:flake8]
 basepython = python
 deps =
-    -rrequirements.txt
     flake8
     pep8-naming
     mccabe


### PR DESCRIPTION
Also add a tox env, that installs sacred in a plain version, to test that it works without optional dependencies.