### PR TITLE
__unicode__ isn't used anymore in py3.

### DIFF
--- a/sacred/config/signature.py
+++ b/sacred/config/signature.py
@@ -83,7 +83,7 @@ class Signature(object):
         self._assert_no_missing_args(args, kwargs, bound)
         return args, kwargs
 
-    def __unicode__(self):
+    def __str__(self):
         pos_args = self.positional_args
         varg = ["*" + self.vararg_name] if self.vararg_name else []
         kwargs = ["{}={}".format(n, v.__repr__())

--- a/tests/test_config/test_signature.py
+++ b/tests/test_config/test_signature.py
@@ -241,7 +241,7 @@ def test_construct_arguments_for_bound_method():
     (bariza, "bariza(a, b, c)")
 ])
 def test_unicode_(func, expected):
-    assert Signature(func).__unicode__() == expected
+    assert str(Signature(func)) == expected
 
 
 @pytest.mark.parametrize('name,func', zip(names, functions))

--- a/tests/test_config/test_signature_py3.py
+++ b/tests/test_config/test_signature_py3.py
@@ -332,12 +332,12 @@ def test_construct_arguments_for_bound_method():
     (onlykwrgs, "onlykwrgs(**kwargs)")
 ])
 def test_unicode_(func, expected):
-    assert Signature(func).__unicode__() == expected
+    assert str(Signature(func)) == expected
 
 
 def test_unicode_special():
     str_signature = "complex_function_name(a=5, b='fo', c=9)"
-    assert str_signature in Signature(complex_function_name).__unicode__()
+    assert str_signature in str(Signature(complex_function_name))
 
 
 @pytest.mark.parametrize('name,func', zip(names, functions))


### PR DESCRIPTION
Unicode is the default for strings in py3. As such `__unicode__` isn't used anymore in the standard library. Py2 unicode is equivalent to python 3 's strings. So it's the best replacement I could find.

Some material: 
https://docs.python.org/2.7/reference/datamodel.html
https://docs.python.org/3.7/reference/datamodel.html
