### PR TITLE
Add types hints for ingredients and experiment

### DIFF
--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -6,7 +6,7 @@ import inspect
 import os.path
 import sys
 from collections import OrderedDict
-from typing import Iterator, Optional
+from typing import Sequence, Optional
 
 from docopt import docopt, printable_usage
 
@@ -37,7 +37,7 @@ class Experiment(Ingredient):
     """
 
     def __init__(self, name: Optional[str] = None,
-                 ingredients: Iterator[Ingredient] = (),
+                 ingredients: Sequence[Ingredient] = (),
                  interactive: bool = False,
                  base_dir: Optional[PathType] = None):
         """

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -6,6 +6,7 @@ import inspect
 import os.path
 import sys
 from collections import OrderedDict
+from typing import Iterator, Optional
 
 from docopt import docopt, printable_usage
 
@@ -19,7 +20,7 @@ from sacred.config.signature import Signature
 from sacred.ingredient import Ingredient
 from sacred.initialize import create_run
 from sacred.utils import print_filtered_stacktrace, ensure_wellformed_argv, \
-    SacredError, format_sacred_error
+    SacredError, format_sacred_error, PathType
 
 __all__ = ('Experiment',)
 
@@ -35,8 +36,10 @@ class Experiment(Ingredient):
     things in any experiment-file.
     """
 
-    def __init__(self, name=None, ingredients=(), interactive=False,
-                 base_dir=None):
+    def __init__(self, name: Optional[str] = None,
+                 ingredients: Iterator[Ingredient] = (),
+                 interactive: bool = False,
+                 base_dir: Optional[PathType] = None):
         """
         Create a new experiment with the given name and optional ingredients.
 

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -3,6 +3,8 @@
 
 import inspect
 import os.path
+from sacred.utils import PathType
+from typing import Iterator, Optional
 
 from collections import OrderedDict
 
@@ -47,8 +49,11 @@ class Ingredient:
     Ingredients can themselves use ingredients.
     """
 
-    def __init__(self, path, ingredients=(), interactive=False,
-                 _caller_globals=None, base_dir=None):
+    def __init__(self, path: PathType,
+                 ingredients: Iterator['Ingredient'] = (),
+                 interactive: bool = False,
+                 _caller_globals: Optional[dict] = None,
+                 base_dir: Optional[PathType] = None):
         self.path = path
         self.config_hooks = []
         self.configurations = []

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -4,7 +4,7 @@
 import inspect
 import os.path
 from sacred.utils import PathType
-from typing import Iterator, Optional
+from typing import Sequence, Optional
 
 from collections import OrderedDict
 
@@ -50,7 +50,7 @@ class Ingredient:
     """
 
     def __init__(self, path: PathType,
-                 ingredients: Iterator['Ingredient'] = (),
+                 ingredients: Sequence['Ingredient'] = (),
                  interactive: bool = False,
                  _caller_globals: Optional[dict] = None,
                  base_dir: Optional[PathType] = None):

--- a/sacred/utils.py
+++ b/sacred/utils.py
@@ -16,6 +16,7 @@ import traceback as tb
 from functools import partial
 from packaging import version
 from typing import Union
+from pathlib import Path
 
 import wrapt
 
@@ -38,7 +39,7 @@ PATHCHANGE = object()
 
 PYTHON_IDENTIFIER = re.compile("^[a-zA-Z_][_a-zA-Z0-9]*$")
 
-PathType = Union[str, bytes, os.PathLike]
+PathType = Union[str, bytes, Path]
 
 
 class ObserverError(Exception):

--- a/sacred/utils.py
+++ b/sacred/utils.py
@@ -16,7 +16,6 @@ import traceback as tb
 from functools import partial
 from packaging import version
 from typing import Union
-from pathlib import Path
 
 import wrapt
 
@@ -39,7 +38,7 @@ PATHCHANGE = object()
 
 PYTHON_IDENTIFIER = re.compile("^[a-zA-Z_][_a-zA-Z0-9]*$")
 
-PathType = Union[str, bytes, Path]
+PathType = Union[str, bytes, os.PathLike]
 
 
 class ObserverError(Exception):

--- a/sacred/utils.py
+++ b/sacred/utils.py
@@ -15,6 +15,8 @@ import threading
 import traceback as tb
 from functools import partial
 from packaging import version
+from typing import Union
+from pathlib import Path
 
 import wrapt
 
@@ -27,7 +29,8 @@ __all__ = ["NO_LOGGER", "PYTHON_IDENTIFIER", "CircularDependencyError",
            "convert_to_nested_dict", "convert_camel_case_to_snake_case",
            "print_filtered_stacktrace", "is_subdir",
            "optional_kwargs_decorator", "get_inheritors",
-           "apply_backspaces_and_linefeeds", "rel_path", "IntervalTimer"]
+           "apply_backspaces_and_linefeeds", "rel_path", "IntervalTimer",
+           "PathType"]
 
 NO_LOGGER = logging.getLogger('ignore')
 NO_LOGGER.disabled = 1
@@ -35,6 +38,8 @@ NO_LOGGER.disabled = 1
 PATHCHANGE = object()
 
 PYTHON_IDENTIFIER = re.compile("^[a-zA-Z_][_a-zA-Z0-9]*$")
+
+PathType = Union[str, bytes, Path]
 
 
 class ObserverError(Exception):


### PR DESCRIPTION
Adding type hints on the API surface allows IDEs and static code analysis tools to do a better job at detecting user errors.

It's also quite informative when using IDEs as you can get hints in the auto-completion.