### PR TITLE
Added the test for the import error.

### DIFF
--- a/sacred/observers/sql.py
+++ b/sacred/observers/sql.py
@@ -1,16 +1,12 @@
 #!/usr/bin/env python
 # coding=utf-8
 
-import hashlib
 import json
-import os
 from threading import Lock
 
-import sacred.optional as opt
 from sacred.commandline_options import CommandLineOption
-from sacred.dependencies import get_digest
 from sacred.observers.base import RunObserver
-from sacred.serializer import flatten, restore
+from sacred.serializer import flatten
 
 DEFAULT_SQL_PRIORITY = 40
 
@@ -20,6 +16,8 @@ DEFAULT_SQL_PRIORITY = 40
 class SqlObserver(RunObserver):
     @classmethod
     def create(cls, url, echo=False, priority=DEFAULT_SQL_PRIORITY):
+        from sqlalchemy.orm import sessionmaker, scoped_session
+        from .sql_bases import sa
         engine = sa.create_engine(url, echo=echo)
         session_factory = sessionmaker(bind=engine)
         # make session thread-local to avoid problems with sqlite (see #275)
@@ -46,7 +44,7 @@ class SqlObserver(RunObserver):
 
     def _add_event(self, ex_info, command, host_info, config,
                    meta_info, _id, status, **kwargs):
-
+        from .sql_bases import Base, Experiment, Host, Run
         Base.metadata.create_all(self.engine)
         sql_exp = Experiment.get_or_create(ex_info, self.session)
         sql_host = Host.get_or_create(host_info, self.session)
@@ -92,11 +90,13 @@ class SqlObserver(RunObserver):
         self.save()
 
     def resource_event(self, filename):
+        from .sql_bases import Resource
         res = Resource.get_or_create(filename, self.session)
         self.run.resources.append(res)
         self.save()
 
     def artifact_event(self, name, filename, metadata=None, content_type=None):
+        from .sql_bases import Artifact
         a = Artifact.create(name, filename)
         self.run.artifacts.append(a)
         self.save()
@@ -106,6 +106,7 @@ class SqlObserver(RunObserver):
             self.session.commit()
 
     def query(self, _id):
+        from .sql_bases import Run
         run = self.session.query(Run).filter_by(id=_id).first()
         return run.to_json()
 
@@ -130,258 +131,3 @@ class SqlOption(CommandLineOption):
     @classmethod
     def apply(cls, args, run):
         run.observers.append(SqlObserver.create(args))
-
-
-# ################################ ORM ###################################### #
-if opt.has_sqlalchemy:  # noqa
-    import sqlalchemy as sa
-    from sqlalchemy.ext.declarative import declarative_base
-    from sqlalchemy.orm import sessionmaker, scoped_session
-
-    Base = declarative_base()
-
-    class Source(Base):
-        __tablename__ = 'source'
-
-        @classmethod
-        def get_or_create(cls, filename, md5sum, session, basedir):
-            instance = session.query(cls).filter_by(filename=filename,
-                                                    md5sum=md5sum).first()
-            if instance:
-                return instance
-            full_path = os.path.join(basedir, filename)
-            md5sum_ = get_digest(full_path)
-            assert md5sum_ == md5sum, 'found md5 mismatch for {}: {} != {}'\
-                .format(filename, md5sum, md5sum_)
-            with open(full_path, 'r') as f:
-                return cls(filename=filename, md5sum=md5sum, content=f.read())
-
-        source_id = sa.Column(sa.Integer, primary_key=True)
-        filename = sa.Column(sa.String(256))
-        md5sum = sa.Column(sa.String(32))
-        content = sa.Column(sa.Text)
-
-        def to_json(self):
-            return {'filename': self.filename,
-                    'md5sum': self.md5sum}
-
-    class Dependency(Base):
-        __tablename__ = 'dependency'
-
-        @classmethod
-        def get_or_create(cls, dep, session):
-            name, _, version = dep.partition('==')
-            instance = session.query(cls).filter_by(name=name,
-                                                    version=version).first()
-            if instance:
-                return instance
-            return cls(name=name, version=version)
-
-        dependency_id = sa.Column(sa.Integer, primary_key=True)
-        name = sa.Column(sa.String(32))
-        version = sa.Column(sa.String(16))
-
-        def to_json(self):
-            return "{}=={}".format(self.name, self.version)
-
-    class Artifact(Base):
-        __tablename__ = 'artifact'
-
-        @classmethod
-        def create(cls, name, filename):
-            with open(filename, 'rb') as f:
-                return cls(filename=name, content=f.read())
-
-        artifact_id = sa.Column(sa.Integer, primary_key=True)
-        filename = sa.Column(sa.String(64))
-        content = sa.Column(sa.LargeBinary)
-
-        run_id = sa.Column(sa.String(24), sa.ForeignKey('run.run_id'))
-        run = sa.orm.relationship("Run", backref=sa.orm.backref('artifacts'))
-
-        def to_json(self):
-            return {'_id': self.artifact_id,
-                    'filename': self.filename}
-
-    class Resource(Base):
-        __tablename__ = 'resource'
-
-        @classmethod
-        def get_or_create(cls, filename, session):
-            md5sum = get_digest(filename)
-            instance = session.query(cls).filter_by(filename=filename,
-                                                    md5sum=md5sum).first()
-            if instance:
-                return instance
-            with open(filename, 'rb') as f:
-                return cls(filename=filename, md5sum=md5sum, content=f.read())
-
-        resource_id = sa.Column(sa.Integer, primary_key=True)
-        filename = sa.Column(sa.String(256))
-        md5sum = sa.Column(sa.String(32))
-        content = sa.Column(sa.LargeBinary)
-
-        def to_json(self):
-            return {'filename': self.filename,
-                    'md5sum': self.md5sum}
-
-    class Host(Base):
-        __tablename__ = 'host'
-
-        @classmethod
-        def get_or_create(cls, host_info, session):
-            h = dict(
-                hostname=host_info['hostname'],
-                cpu=host_info['cpu'],
-                os=host_info['os'][0],
-                os_info=host_info['os'][1],
-                python_version=host_info['python_version']
-            )
-
-            return session.query(cls).filter_by(**h).first() or cls(**h)
-
-        host_id = sa.Column(sa.Integer, primary_key=True)
-        cpu = sa.Column(sa.String(64))
-        hostname = sa.Column(sa.String(64))
-        os = sa.Column(sa.String(16))
-        os_info = sa.Column(sa.String(64))
-        python_version = sa.Column(sa.String(16))
-
-        def to_json(self):
-            return {'cpu': self.cpu,
-                    'hostname': self.hostname,
-                    'os': [self.os, self.os_info],
-                    'python_version': self.python_version}
-
-    experiment_source_association = sa.Table(
-        'experiments_sources', Base.metadata,
-        sa.Column('experiment_id', sa.Integer,
-                  sa.ForeignKey('experiment.experiment_id')),
-        sa.Column('source_id', sa.Integer, sa.ForeignKey('source.source_id'))
-    )
-
-    experiment_dependency_association = sa.Table(
-        'experiments_dependencies', Base.metadata,
-        sa.Column('experiment_id', sa.Integer,
-                  sa.ForeignKey('experiment.experiment_id')),
-        sa.Column('dependency_id', sa.Integer,
-                  sa.ForeignKey('dependency.dependency_id'))
-    )
-
-    class Experiment(Base):
-        __tablename__ = 'experiment'
-
-        @classmethod
-        def get_or_create(cls, ex_info, session):
-            name = ex_info['name']
-            # Compute a MD5sum of the ex_info to determine its uniqueness
-            h = hashlib.md5()
-            h.update(json.dumps(ex_info).encode())
-            md5 = h.hexdigest()
-            instance = session.query(cls).filter_by(name=name,
-                                                    md5sum=md5).first()
-            if instance:
-                return instance
-
-            dependencies = [Dependency.get_or_create(d, session)
-                            for d in ex_info['dependencies']]
-            sources = [Source.get_or_create(s, md5sum, session,
-                                            ex_info['base_dir'])
-                       for s, md5sum in ex_info['sources']]
-
-            return cls(name=name, dependencies=dependencies, sources=sources,
-                       md5sum=md5, base_dir=ex_info['base_dir'])
-
-        experiment_id = sa.Column(sa.Integer, primary_key=True)
-        name = sa.Column(sa.String(32))
-        md5sum = sa.Column(sa.String(32))
-        base_dir = sa.Column(sa.String(64))
-        sources = sa.orm.relationship("Source",
-                                      secondary=experiment_source_association,
-                                      backref="experiments")
-        dependencies = sa.orm.relationship(
-            "Dependency",
-            secondary=experiment_dependency_association,
-            backref="experiments")
-
-        def to_json(self):
-            return {'name': self.name,
-                    'base_dir': self.base_dir,
-                    'sources': [s.to_json() for s in self.sources],
-                    'dependencies': [d.to_json() for d in self.dependencies]}
-
-    run_resource_association = sa.Table(
-        'runs_resources', Base.metadata,
-        sa.Column('run_id', sa.String(24), sa.ForeignKey('run.run_id')),
-        sa.Column('resource_id', sa.Integer,
-                  sa.ForeignKey('resource.resource_id'))
-    )
-
-    class Run(Base):
-        __tablename__ = 'run'
-        id = sa.Column(sa.Integer, primary_key=True)
-
-        run_id = sa.Column(sa.String(24), unique=True)
-
-        command = sa.Column(sa.String(64))
-
-        # times
-        start_time = sa.Column(sa.DateTime)
-        heartbeat = sa.Column(sa.DateTime)
-        stop_time = sa.Column(sa.DateTime)
-        queue_time = sa.Column(sa.DateTime)
-
-        # meta info
-        priority = sa.Column(sa.Float)
-        comment = sa.Column(sa.Text)
-
-        fail_trace = sa.Column(sa.Text)
-
-        # Captured out
-        # TODO: move to separate table?
-        captured_out = sa.Column(sa.Text)
-
-        # Configuration & info
-        # TODO: switch type to json if possible
-        config = sa.Column(sa.Text)
-        info = sa.Column(sa.Text)
-
-        status = sa.Column(sa.Enum("RUNNING", "COMPLETED", "INTERRUPTED",
-                                   "TIMEOUT", "FAILED", name="status_enum"))
-
-        host_id = sa.Column(sa.Integer, sa.ForeignKey('host.host_id'))
-        host = sa.orm.relationship("Host", backref=sa.orm.backref('runs'))
-
-        experiment_id = sa.Column(sa.Integer,
-                                  sa.ForeignKey('experiment.experiment_id'))
-        experiment = sa.orm.relationship("Experiment",
-                                         backref=sa.orm.backref('runs'))
-
-        # artifacts = backref
-        resources = sa.orm.relationship("Resource",
-                                        secondary=run_resource_association,
-                                        backref="runs")
-
-        result = sa.Column(sa.Float)
-
-        def to_json(self):
-            return {
-                '_id': self.run_id,
-                'command': self.command,
-                'start_time': self.start_time,
-                'heartbeat': self.heartbeat,
-                'stop_time': self.stop_time,
-                'queue_time': self.queue_time,
-                'status': self.status,
-                'result': self.result,
-                'meta': {
-                    'comment': self.comment,
-                    'priority': self.priority},
-                'resources': [r.to_json() for r in self.resources],
-                'artifacts': [a.to_json() for a in self.artifacts],
-                'host': self.host.to_json(),
-                'experiment': self.experiment.to_json(),
-                'config': restore(json.loads(self.config)),
-                'captured_out': self.captured_out,
-                'fail_trace': self.fail_trace,
-            }

--- a/sacred/observers/sql.py
+++ b/sacred/observers/sql.py
@@ -17,7 +17,7 @@ class SqlObserver(RunObserver):
     @classmethod
     def create(cls, url, echo=False, priority=DEFAULT_SQL_PRIORITY):
         from sqlalchemy.orm import sessionmaker, scoped_session
-        from .sql_bases import sa
+        import sqlalchemy as sa
         engine = sa.create_engine(url, echo=echo)
         session_factory = sessionmaker(bind=engine)
         # make session thread-local to avoid problems with sqlite (see #275)

--- a/sacred/observers/sql_bases.py
+++ b/sacred/observers/sql_bases.py
@@ -9,7 +9,9 @@ from sqlalchemy.orm import sessionmaker
 from sacred.dependencies import get_digest
 from sacred.serializer import restore
 
+
 Base = declarative_base()
+
 
 class Source(Base):
     __tablename__ = 'source'
@@ -36,6 +38,7 @@ class Source(Base):
         return {'filename': self.filename,
                 'md5sum': self.md5sum}
 
+
 class Dependency(Base):
     __tablename__ = 'dependency'
 
@@ -55,6 +58,7 @@ class Dependency(Base):
     def to_json(self):
         return "{}=={}".format(self.name, self.version)
 
+
 class Artifact(Base):
     __tablename__ = 'artifact'
 
@@ -73,6 +77,7 @@ class Artifact(Base):
     def to_json(self):
         return {'_id': self.artifact_id,
                 'filename': self.filename}
+
 
 class Resource(Base):
     __tablename__ = 'resource'
@@ -95,6 +100,7 @@ class Resource(Base):
     def to_json(self):
         return {'filename': self.filename,
                 'md5sum': self.md5sum}
+
 
 class Host(Base):
     __tablename__ = 'host'
@@ -124,6 +130,7 @@ class Host(Base):
                 'os': [self.os, self.os_info],
                 'python_version': self.python_version}
 
+
 experiment_source_association = sa.Table(
     'experiments_sources', Base.metadata,
     sa.Column('experiment_id', sa.Integer,
@@ -138,6 +145,7 @@ experiment_dependency_association = sa.Table(
     sa.Column('dependency_id', sa.Integer,
               sa.ForeignKey('dependency.dependency_id'))
 )
+
 
 class Experiment(Base):
     __tablename__ = 'experiment'
@@ -187,6 +195,7 @@ run_resource_association = sa.Table(
     sa.Column('resource_id', sa.Integer,
               sa.ForeignKey('resource.resource_id'))
 )
+
 
 class Run(Base):
     __tablename__ = 'run'

--- a/sacred/observers/sql_bases.py
+++ b/sacred/observers/sql_bases.py
@@ -4,7 +4,6 @@ import os
 
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
 
 from sacred.dependencies import get_digest
 from sacred.serializer import restore
@@ -188,6 +187,7 @@ class Experiment(Base):
                 'base_dir': self.base_dir,
                 'sources': [s.to_json() for s in self.sources],
                 'dependencies': [d.to_json() for d in self.dependencies]}
+
 
 run_resource_association = sa.Table(
     'runs_resources', Base.metadata,

--- a/sacred/observers/sql_bases.py
+++ b/sacred/observers/sql_bases.py
@@ -1,0 +1,258 @@
+import hashlib
+import json
+import os
+
+import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+from sacred.dependencies import get_digest
+from sacred.serializer import restore
+
+Base = declarative_base()
+
+class Source(Base):
+    __tablename__ = 'source'
+
+    @classmethod
+    def get_or_create(cls, filename, md5sum, session, basedir):
+        instance = session.query(cls).filter_by(filename=filename,
+                                                md5sum=md5sum).first()
+        if instance:
+            return instance
+        full_path = os.path.join(basedir, filename)
+        md5sum_ = get_digest(full_path)
+        assert md5sum_ == md5sum, 'found md5 mismatch for {}: {} != {}'\
+            .format(filename, md5sum, md5sum_)
+        with open(full_path, 'r') as f:
+            return cls(filename=filename, md5sum=md5sum, content=f.read())
+
+    source_id = sa.Column(sa.Integer, primary_key=True)
+    filename = sa.Column(sa.String(256))
+    md5sum = sa.Column(sa.String(32))
+    content = sa.Column(sa.Text)
+
+    def to_json(self):
+        return {'filename': self.filename,
+                'md5sum': self.md5sum}
+
+class Dependency(Base):
+    __tablename__ = 'dependency'
+
+    @classmethod
+    def get_or_create(cls, dep, session):
+        name, _, version = dep.partition('==')
+        instance = session.query(cls).filter_by(name=name,
+                                                version=version).first()
+        if instance:
+            return instance
+        return cls(name=name, version=version)
+
+    dependency_id = sa.Column(sa.Integer, primary_key=True)
+    name = sa.Column(sa.String(32))
+    version = sa.Column(sa.String(16))
+
+    def to_json(self):
+        return "{}=={}".format(self.name, self.version)
+
+class Artifact(Base):
+    __tablename__ = 'artifact'
+
+    @classmethod
+    def create(cls, name, filename):
+        with open(filename, 'rb') as f:
+            return cls(filename=name, content=f.read())
+
+    artifact_id = sa.Column(sa.Integer, primary_key=True)
+    filename = sa.Column(sa.String(64))
+    content = sa.Column(sa.LargeBinary)
+
+    run_id = sa.Column(sa.String(24), sa.ForeignKey('run.run_id'))
+    run = sa.orm.relationship("Run", backref=sa.orm.backref('artifacts'))
+
+    def to_json(self):
+        return {'_id': self.artifact_id,
+                'filename': self.filename}
+
+class Resource(Base):
+    __tablename__ = 'resource'
+
+    @classmethod
+    def get_or_create(cls, filename, session):
+        md5sum = get_digest(filename)
+        instance = session.query(cls).filter_by(filename=filename,
+                                                md5sum=md5sum).first()
+        if instance:
+            return instance
+        with open(filename, 'rb') as f:
+            return cls(filename=filename, md5sum=md5sum, content=f.read())
+
+    resource_id = sa.Column(sa.Integer, primary_key=True)
+    filename = sa.Column(sa.String(256))
+    md5sum = sa.Column(sa.String(32))
+    content = sa.Column(sa.LargeBinary)
+
+    def to_json(self):
+        return {'filename': self.filename,
+                'md5sum': self.md5sum}
+
+class Host(Base):
+    __tablename__ = 'host'
+
+    @classmethod
+    def get_or_create(cls, host_info, session):
+        h = dict(
+            hostname=host_info['hostname'],
+            cpu=host_info['cpu'],
+            os=host_info['os'][0],
+            os_info=host_info['os'][1],
+            python_version=host_info['python_version']
+        )
+
+        return session.query(cls).filter_by(**h).first() or cls(**h)
+
+    host_id = sa.Column(sa.Integer, primary_key=True)
+    cpu = sa.Column(sa.String(64))
+    hostname = sa.Column(sa.String(64))
+    os = sa.Column(sa.String(16))
+    os_info = sa.Column(sa.String(64))
+    python_version = sa.Column(sa.String(16))
+
+    def to_json(self):
+        return {'cpu': self.cpu,
+                'hostname': self.hostname,
+                'os': [self.os, self.os_info],
+                'python_version': self.python_version}
+
+experiment_source_association = sa.Table(
+    'experiments_sources', Base.metadata,
+    sa.Column('experiment_id', sa.Integer,
+              sa.ForeignKey('experiment.experiment_id')),
+    sa.Column('source_id', sa.Integer, sa.ForeignKey('source.source_id'))
+)
+
+experiment_dependency_association = sa.Table(
+    'experiments_dependencies', Base.metadata,
+    sa.Column('experiment_id', sa.Integer,
+              sa.ForeignKey('experiment.experiment_id')),
+    sa.Column('dependency_id', sa.Integer,
+              sa.ForeignKey('dependency.dependency_id'))
+)
+
+class Experiment(Base):
+    __tablename__ = 'experiment'
+
+    @classmethod
+    def get_or_create(cls, ex_info, session):
+        name = ex_info['name']
+        # Compute a MD5sum of the ex_info to determine its uniqueness
+        h = hashlib.md5()
+        h.update(json.dumps(ex_info).encode())
+        md5 = h.hexdigest()
+        instance = session.query(cls).filter_by(name=name,
+                                                md5sum=md5).first()
+        if instance:
+            return instance
+
+        dependencies = [Dependency.get_or_create(d, session)
+                        for d in ex_info['dependencies']]
+        sources = [Source.get_or_create(s, md5sum, session,
+                                        ex_info['base_dir'])
+                   for s, md5sum in ex_info['sources']]
+
+        return cls(name=name, dependencies=dependencies, sources=sources,
+                   md5sum=md5, base_dir=ex_info['base_dir'])
+
+    experiment_id = sa.Column(sa.Integer, primary_key=True)
+    name = sa.Column(sa.String(32))
+    md5sum = sa.Column(sa.String(32))
+    base_dir = sa.Column(sa.String(64))
+    sources = sa.orm.relationship("Source",
+                                  secondary=experiment_source_association,
+                                  backref="experiments")
+    dependencies = sa.orm.relationship(
+        "Dependency",
+        secondary=experiment_dependency_association,
+        backref="experiments")
+
+    def to_json(self):
+        return {'name': self.name,
+                'base_dir': self.base_dir,
+                'sources': [s.to_json() for s in self.sources],
+                'dependencies': [d.to_json() for d in self.dependencies]}
+
+run_resource_association = sa.Table(
+    'runs_resources', Base.metadata,
+    sa.Column('run_id', sa.String(24), sa.ForeignKey('run.run_id')),
+    sa.Column('resource_id', sa.Integer,
+              sa.ForeignKey('resource.resource_id'))
+)
+
+class Run(Base):
+    __tablename__ = 'run'
+    id = sa.Column(sa.Integer, primary_key=True)
+
+    run_id = sa.Column(sa.String(24), unique=True)
+
+    command = sa.Column(sa.String(64))
+
+    # times
+    start_time = sa.Column(sa.DateTime)
+    heartbeat = sa.Column(sa.DateTime)
+    stop_time = sa.Column(sa.DateTime)
+    queue_time = sa.Column(sa.DateTime)
+
+    # meta info
+    priority = sa.Column(sa.Float)
+    comment = sa.Column(sa.Text)
+
+    fail_trace = sa.Column(sa.Text)
+
+    # Captured out
+    # TODO: move to separate table?
+    captured_out = sa.Column(sa.Text)
+
+    # Configuration & info
+    # TODO: switch type to json if possible
+    config = sa.Column(sa.Text)
+    info = sa.Column(sa.Text)
+
+    status = sa.Column(sa.Enum("RUNNING", "COMPLETED", "INTERRUPTED",
+                               "TIMEOUT", "FAILED", name="status_enum"))
+
+    host_id = sa.Column(sa.Integer, sa.ForeignKey('host.host_id'))
+    host = sa.orm.relationship("Host", backref=sa.orm.backref('runs'))
+
+    experiment_id = sa.Column(sa.Integer,
+                              sa.ForeignKey('experiment.experiment_id'))
+    experiment = sa.orm.relationship("Experiment",
+                                     backref=sa.orm.backref('runs'))
+
+    # artifacts = backref
+    resources = sa.orm.relationship("Resource",
+                                    secondary=run_resource_association,
+                                    backref="runs")
+
+    result = sa.Column(sa.Float)
+
+    def to_json(self):
+        return {
+            '_id': self.run_id,
+            'command': self.command,
+            'start_time': self.start_time,
+            'heartbeat': self.heartbeat,
+            'stop_time': self.stop_time,
+            'queue_time': self.queue_time,
+            'status': self.status,
+            'result': self.result,
+            'meta': {
+                'comment': self.comment,
+                'priority': self.priority},
+            'resources': [r.to_json() for r in self.resources],
+            'artifacts': [a.to_json() for a in self.artifacts],
+            'host': self.host.to_json(),
+            'experiment': self.experiment.to_json(),
+            'config': restore(json.loads(self.config)),
+            'captured_out': self.captured_out,
+            'fail_trace': self.fail_trace,
+        }

--- a/tests/test_observers/test_sql_observer.py
+++ b/tests/test_observers/test_sql_observer.py
@@ -12,8 +12,9 @@ from sacred.serializer import json
 
 sqlalchemy = pytest.importorskip("sqlalchemy")
 
-from sacred.observers.sql import (SqlObserver, Host, Experiment, Run, Source,
-                                  Resource)
+from sacred.observers.sql import SqlObserver
+from sacred.observers.sql_bases import Host, Experiment, Run, Source, Resource
+
 
 T1 = datetime.datetime(1999, 5, 4, 3, 2, 1, 0)
 T2 = datetime.datetime(1999, 5, 5, 5, 5, 5, 5)

--- a/tests/test_observers/test_sql_observer_not_installed.py
+++ b/tests/test_observers/test_sql_observer_not_installed.py
@@ -1,0 +1,25 @@
+import pytest
+from sacred.optional import has_sqlalchemy
+from sacred.observers import SqlObserver
+from sacred import Experiment
+
+
+@pytest.fixture
+def ex():
+    return Experiment('ator3000')
+
+
+@pytest.mark.skipif(has_sqlalchemy, reason='We are testing the import error.')
+def test_importerror_sql(ex):
+    with pytest.raises(ImportError):
+        ex.observers.append(SqlObserver.create('some_uri'))
+
+        @ex.config
+        def cfg():
+            a = {'b': 1}
+
+        @ex.main
+        def foo(a):
+            return a['b']
+
+        ex.run()

--- a/tox.ini
+++ b/tox.ini
@@ -58,8 +58,7 @@ deps =
     pytest==4.3.0
     mock==2.0.0
 commands = 
-    pytest --ignore=tests/test_observers \
-        {posargs} 
+    pytest {posargs}
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
We have an issue with error messages for optional dependencies. For exemple, trying to use the sql observer without sql installed throws the following error:

```
tests/test_observers/test_sql_observer_not_installed.py:11 (test_importerror_sql)
ex = <sacred.experiment.Experiment object at 0x7f5495d9f4a8>

    @pytest.mark.skipif(has_sqlalchemy, reason='We are testing the import error.')
    def test_importerror_sql(ex):
        with pytest.raises(ImportError):
>           ex.observers.append(SqlObserver.create('some_uri'))

test_sql_observer_not_installed.py:15: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cls = <class 'sacred.observers.sql.SqlObserver'>, url = 'some_uri', echo = False
priority = 40

    @classmethod
    def create(cls, url, echo=False, priority=DEFAULT_SQL_PRIORITY):
>       engine = sa.create_engine(url, echo=echo)
E       NameError: name 'sa' is not defined

../../sacred/observers/sql.py:23: NameError
```

Not very helpful. See [here](https://travis-ci.org/IDSIA/sacred/jobs/565989234) the travis log for the test I added.

This PR makes sure that we have a proper error message.

I had to enable the test for the observers in the "setup" build. Otherwise the added test will never run.

With the new setup, the error message is:

```
Traceback (most recent call last):
  File "/mnt/c/Users/gdemarmi/Desktop/projects/sacred/trying_stuff.py", line 9, in <module>
    ex.observers.append(SqlObserver.create('some_uri'))
  File "/mnt/c/Users/gdemarmi/Desktop/projects/sacred/sacred/observers/sql.py", line 19, in create
    from sqlalchemy.orm import sessionmaker, scoped_session
ModuleNotFoundError: No module named 'sqlalchemy'
```

The majority of the change is just a copy past between sql.py and sql_bases.py.