### PR TITLE
Moving more slowly to pathlib

### DIFF
--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -4,6 +4,7 @@
 import json
 import os
 import os.path
+from pathlib import Path
 
 from shutil import copyfile
 
@@ -23,23 +24,24 @@ class FileStorageObserver(RunObserver):
     @classmethod
     def create(cls, basedir, resource_dir=None, source_dir=None,
                template=None, priority=DEFAULT_FILE_STORAGE_PRIORITY):
-        resource_dir = resource_dir or os.path.join(basedir, '_resources')
-        source_dir = source_dir or os.path.join(basedir, '_sources')
+        basedir = Path(basedir)
+        resource_dir = resource_dir or basedir / '_resources'
+        source_dir = source_dir or basedir / '_sources'
         if template is not None:
             if not os.path.exists(template):
                 raise FileNotFoundError("Couldn't find template file '{}'"
                                         .format(template))
         else:
-            template = os.path.join(basedir, 'template.html')
-            if not os.path.exists(template):
+            template = basedir / 'template.html'
+            if not template.exists():
                 template = None
         return cls(basedir, resource_dir, source_dir, template, priority)
 
     def __init__(self, basedir, resource_dir, source_dir, template,
                  priority=DEFAULT_FILE_STORAGE_PRIORITY):
-        self.basedir = basedir
-        self.resource_dir = resource_dir
-        self.source_dir = source_dir
+        self.basedir = str(basedir)
+        self.resource_dir = str(resource_dir)
+        self.source_dir = str(source_dir)
         self.template = template
         self.priority = priority
         self.dir = None

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -5,6 +5,7 @@ import json
 import os
 import os.path
 from pathlib import Path
+from typing import Optional
 
 from shutil import copyfile
 
@@ -13,6 +14,7 @@ from sacred.dependencies import get_digest
 from sacred.observers.base import RunObserver
 from sacred import optional as opt
 from sacred.serializer import flatten
+from sacred.utils import PathType
 
 
 DEFAULT_FILE_STORAGE_PRIORITY = 20
@@ -22,8 +24,11 @@ class FileStorageObserver(RunObserver):
     VERSION = 'FileStorageObserver-0.7.0'
 
     @classmethod
-    def create(cls, basedir, resource_dir=None, source_dir=None,
-               template=None, priority=DEFAULT_FILE_STORAGE_PRIORITY):
+    def create(cls, basedir: PathType,
+               resource_dir: Optional[PathType] = None,
+               source_dir: Optional[PathType] = None,
+               template: Optional[PathType] = None,
+               priority: int = DEFAULT_FILE_STORAGE_PRIORITY):
         basedir = Path(basedir)
         resource_dir = resource_dir or basedir / '_resources'
         source_dir = source_dir or basedir / '_sources'
@@ -42,7 +47,7 @@ class FileStorageObserver(RunObserver):
         self.basedir = str(basedir)
         self.resource_dir = str(resource_dir)
         self.source_dir = str(source_dir)
-        self.template = template
+        self.template = template if template is None else str(template)
         self.priority = priority
         self.dir = None
         self.run_entry = None


### PR DESCRIPTION
We need to be slow in the changes since we still support python  3.5 and in python 3.5, os.path is not compatible with Pathlib.