### PR TITLE
Using pathlib to simplify is_local_source.

### DIFF
--- a/sacred/dependencies.py
+++ b/sacred/dependencies.py
@@ -270,14 +270,6 @@ def convert_path_to_module_parts(path):
     return module_parts
 
 
-def resolve_not_strict(path):
-    """Backport of the strict flag in Path.resolve()"""
-    if sys.version_info < (3, 6):
-        return Path(os.path.abspath(os.path.realpath(path)))
-    else:
-        return Path(path).resolve()
-
-
 def is_local_source(filename, modname, experiment_path):
     """Check if a module comes from the given experiment path.
 
@@ -302,8 +294,8 @@ def is_local_source(filename, modname, experiment_path):
         True if the module was imported locally from (a subdir of) the
         experiment_path, and False otherwise.
     """
-    filename = resolve_not_strict(filename)
-    experiment_path = resolve_not_strict(experiment_path)
+    filename = Path(os.path.abspath(os.path.realpath(filename)))
+    experiment_path = Path(os.path.abspath(os.path.realpath(experiment_path)))
     if experiment_path not in filename.parents:
         return False
     rel_path = filename.relative_to(experiment_path)

--- a/sacred/dependencies.py
+++ b/sacred/dependencies.py
@@ -12,7 +12,7 @@ import pkg_resources
 
 import sacred.optional as opt
 from sacred import SETTINGS
-from sacred.utils import is_subdir, iter_prefixes
+from sacred.utils import iter_prefixes
 
 MB = 1048576
 MODULE_BLACKLIST = set(sys.builtin_module_names)

--- a/sacred/dependencies.py
+++ b/sacred/dependencies.py
@@ -6,7 +6,7 @@ import hashlib
 import os.path
 import re
 import sys
-import pathlib
+from pathlib import Path
 
 import pkg_resources
 
@@ -260,7 +260,7 @@ class PackageDependency:
 
 def convert_path_to_module_parts(path):
     """Convert path to a python file into list of module names."""
-    module_parts = list(pathlib.Path(path).parts)
+    module_parts = list(path.parts)
     if module_parts[-1] in ['__init__.py', '__init__.pyc']:
         # remove trailing __init__.py
         module_parts = module_parts[:-1]
@@ -294,9 +294,11 @@ def is_local_source(filename, modname, experiment_path):
         True if the module was imported locally from (a subdir of) the
         experiment_path, and False otherwise.
     """
-    if not is_subdir(filename, experiment_path):
+    filename = Path(filename).resolve()
+    experiment_path = Path(experiment_path).resolve()
+    if experiment_path not in filename.parents:
         return False
-    rel_path = os.path.relpath(filename, experiment_path)
+    rel_path = filename.relative_to(experiment_path)
     path_parts = convert_path_to_module_parts(rel_path)
 
     mod_parts = modname.split('.')
@@ -304,7 +306,7 @@ def is_local_source(filename, modname, experiment_path):
         return True
     if len(path_parts) > len(mod_parts):
         return False
-    abs_path_parts = convert_path_to_module_parts(os.path.abspath(filename))
+    abs_path_parts = convert_path_to_module_parts(filename)
     return all([p == m for p, m in zip(reversed(abs_path_parts),
                                        reversed(mod_parts))])
 

--- a/sacred/dependencies.py
+++ b/sacred/dependencies.py
@@ -270,6 +270,13 @@ def convert_path_to_module_parts(path):
     return module_parts
 
 
+def resolve_not_strict(path):
+    """Backport of the strict flag in Path.resolve()"""
+    if sys.version_info < (3, 6):
+        return Path(os.path.abspath(os.path.realpath(path)))
+    else:
+        return Path(path).resolve()
+
 def is_local_source(filename, modname, experiment_path):
     """Check if a module comes from the given experiment path.
 
@@ -294,8 +301,8 @@ def is_local_source(filename, modname, experiment_path):
         True if the module was imported locally from (a subdir of) the
         experiment_path, and False otherwise.
     """
-    filename = Path(filename).resolve()
-    experiment_path = Path(experiment_path).resolve()
+    filename = resolve_not_strict(filename)
+    experiment_path = resolve_not_strict(experiment_path)
     if experiment_path not in filename.parents:
         return False
     rel_path = filename.relative_to(experiment_path)

--- a/sacred/dependencies.py
+++ b/sacred/dependencies.py
@@ -277,6 +277,7 @@ def resolve_not_strict(path):
     else:
         return Path(path).resolve()
 
+
 def is_local_source(filename, modname, experiment_path):
     """Check if a module comes from the given experiment path.
 

--- a/sacred/utils.py
+++ b/sacred/utils.py
@@ -547,13 +547,6 @@ def filtered_traceback_format(tb_exception, chain=True):
     yield from tb_exception.format_exception_only()
 
 
-def is_subdir(path, directory):
-    path = os.path.abspath(os.path.realpath(path)) + os.sep
-    directory = os.path.abspath(os.path.realpath(directory)) + os.sep
-
-    return path.startswith(directory)
-
-
 # noinspection PyUnusedLocal
 @wrapt.decorator
 def optional_kwargs_decorator(wrapped, instance=None, args=None, kwargs=None):

--- a/sacred/utils.py
+++ b/sacred/utils.py
@@ -27,7 +27,7 @@ __all__ = ["NO_LOGGER", "PYTHON_IDENTIFIER", "CircularDependencyError",
            "set_by_dotted_path", "get_by_dotted_path", "iter_path_splits",
            "iter_prefixes", "join_paths", "is_prefix",
            "convert_to_nested_dict", "convert_camel_case_to_snake_case",
-           "print_filtered_stacktrace", "is_subdir",
+           "print_filtered_stacktrace",
            "optional_kwargs_decorator", "get_inheritors",
            "apply_backspaces_and_linefeeds", "rel_path", "IntervalTimer",
            "PathType"]

--- a/sacred/utils.py
+++ b/sacred/utils.py
@@ -6,7 +6,6 @@ import contextlib
 import importlib
 import inspect
 import logging
-import os.path
 import pkgutil
 import re
 import shlex

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@
 import pytest
 
 from sacred.utils import (PATHCHANGE, convert_to_nested_dict,
-                          get_by_dotted_path, is_prefix, is_subdir,
+                          get_by_dotted_path, is_prefix,
                           iter_path_splits, iter_prefixes, iterate_flattened,
                           iterate_flattened_separately, join_paths,
                           recursive_update, set_by_dotted_path, get_inheritors,
@@ -99,24 +99,6 @@ def test_convert_to_nested_dict_nested():
     dotted_dict = {'a.b': {'foo.bar': 8}, 'a.b.foo.baz': 7}
     assert convert_to_nested_dict(dotted_dict) == \
         {'a': {'b': {'foo': {'bar': 8, 'baz': 7}}}}
-
-
-@pytest.mark.parametrize('path,parent,expected', [
-    ('/var/test2', '/var/test', False),
-    ('/var/test', '/var/test2', False),
-    ('var/test2', 'var/test', False),
-    ('var/test', 'var/test2', False),
-    ('/var/test/sub', '/var/test', True),
-    ('/var/test', '/var/test/sub', False),
-    ('var/test/sub', 'var/test', True),
-    ('var/test', 'var/test', True),
-    ('var/test', 'var/test/fake_sub/..', True),
-    ('var/test/sub/sub2/sub3/../..', 'var/test', True),
-    ('var/test/sub', 'var/test/fake_sub/..', True),
-    ('var/test', 'var/test/sub', False)
-])
-def test_is_subdirectory(path, parent, expected):
-    assert is_subdir(path, parent) == expected
 
 
 def test_get_inheritors():


### PR DESCRIPTION
After testing, replacing `os.path.abspath(os.path.realpath())` by `.resolve()` breaks the build on Windows.  Let's keep it like that for now, we'll see later how we remove it.