### PR TITLE
NeptuneObserver

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ MarkupSafe==0.23
 mock==2.0.0
 mongomock==3.7.0
 munch==2.0.4
-neptune>=0.3.5
+neptune-client>=0.3.5
 numpy==1.16.2
 packaging>=18.0
 pandas==0.24.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,7 @@ MarkupSafe==0.23
 mock==2.0.0
 mongomock==3.7.0
 munch==2.0.4
+neptune>=0.3.5
 numpy==1.16.2
 packaging>=18.0
 pandas==0.24.2

--- a/docs/apidoc.rst
+++ b/docs/apidoc.rst
@@ -60,6 +60,10 @@ Observers
     :members:
     :undoc-members:
 
+.. autoclass:: sacred.observers.NeptuneObserver
+    :members:
+    :undoc-members:
+
 Host Info
 =========
 

--- a/docs/observers.rst
+++ b/docs/observers.rst
@@ -695,6 +695,28 @@ The observer is then added to the experment like this:
 To set the bot's profile photo and description, use @BotFather's commands ``/setuserpic`` and ``/setdescription``.
 Note that ``/setuserpic`` requires a *minimum* picture size.
 
+Neptune Observer
+=================
+Neptune observer sends all the experiment metadata to the Neptune app.
+It requires the `Neptune <https://neptune.ml/>`_ package to be installed.
+
+Adding a Neptune Observer
+--------------------
+
+NeptuneObserver can only be added from the Python code.
+You simply need to initialize it with your project name and (optionally) api token.
+
+.. code-block:: python
+
+    from sacred.observers import NeptuneObserver
+    ex.observers.append(NeptuneObserver(api_token='YOUR_API_TOKEN',
+                                        project_name='USER_NAME/PROJECT_NAME'))
+
+.. warning:: Always keep your API token secret - it is like password to the application.
+That is why it is better not to pass your token inside the code but instead
+set it in the environment variable "NEPTUNE_API_TOKEN". To make things simple you can put
+"export NEPTUNE_API_TOKEN='YOUR_LONG_API_TOKEN'" line to your ``~/.bashrc`` or ``~/.bash_profile`` files.
+
 Events
 ======
 A ``started_event`` is fired when a run starts.

--- a/docs/observers.rst
+++ b/docs/observers.rst
@@ -712,10 +712,12 @@ You simply need to initialize it with your project name and (optionally) api tok
     ex.observers.append(NeptuneObserver(api_token='YOUR_API_TOKEN',
                                         project_name='USER_NAME/PROJECT_NAME'))
 
-.. warning:: Always keep your API token secret - it is like password to the application.
-That is why it is better not to pass your token inside the code but instead
-set it in the environment variable "NEPTUNE_API_TOKEN". To make things simple you can put
-"export NEPTUNE_API_TOKEN='YOUR_LONG_API_TOKEN'" line to your ``~/.bashrc`` or ``~/.bash_profile`` files.
+.. warning::
+
+    Always keep your API token secret - it is like password to the application.
+    It is recommended to pass your token via environment variable `NEPTUNE_API_TOKEN`.
+    To make things simple you can put `export NEPTUNE_API_TOKEN=YOUR_LONG_API_TOKEN`
+    line to your `~/.bashrc` or `~/.bash_profile` files.
 
 Events
 ======

--- a/docs/observers.rst
+++ b/docs/observers.rst
@@ -696,12 +696,12 @@ To set the bot's profile photo and description, use @BotFather's commands ``/set
 Note that ``/setuserpic`` requires a *minimum* picture size.
 
 Neptune Observer
-=================
+================
 Neptune observer sends all the experiment metadata to the Neptune app.
 It requires the `Neptune <https://neptune.ml/>`_ package to be installed.
 
 Adding a Neptune Observer
---------------------
+-------------------------
 
 NeptuneObserver can only be added from the Python code.
 You simply need to initialize it with your project name and (optionally) api token.

--- a/sacred/observers/__init__.py
+++ b/sacred/observers/__init__.py
@@ -4,6 +4,7 @@
 from sacred.observers.base import RunObserver
 from sacred.observers.file_storage import FileStorageObserver
 from sacred.observers.mongo import MongoObserver
+from sacred.observers.neptune_obs import NeptuneObserver
 from sacred.observers.sql import SqlObserver
 from sacred.observers.tinydb_hashfs import TinyDbObserver, TinyDbReader
 from sacred.observers.slack import SlackObserver
@@ -13,6 +14,7 @@ from sacred.observers.telegram_obs import TelegramObserver
 __all__ = (
     "FileStorageObserver",
     "RunObserver",
+    "NeptuneObserver",
     "MongoObserver",
     "SqlObserver",
     "TinyDbObserver",

--- a/sacred/observers/neptune_obs.py
+++ b/sacred/observers/neptune_obs.py
@@ -1,0 +1,140 @@
+import collections
+import os
+
+import neptune
+from sacred.dependencies import get_digest
+from sacred.observers import RunObserver
+
+
+class NeptuneObserver(RunObserver):
+    """Logs sacred experiment data to Neptune.
+
+    Sacred observer that logs experiment metadata to neptune.ml app.
+    The experiment data can be accessed and shared via web UI or experiment API.
+    Check Neptune docs for more information https://docs.neptune.ml.
+
+    Args:
+        project_name(str): project name in Neptune app
+        api_token(str): Neptune API token. If it is kept in the NEPTUNE_API_TOKEN environment
+           variable leave None here.
+        source_extensions(list(str)): list of extensions that Neptune should treat as source files
+           extensions and send.
+
+    Examples:
+        Create sacred experiment::
+
+            from numpy.random import permutation
+            from sklearn import svm, datasets
+            from sacred import Experiment
+
+            ex = Experiment('iris_rbf_svm')
+
+        Add Neptune observer::
+
+            from neptunecontrib.monitoring.sacred_integration import NeptuneObserver
+            ex.observers.append(NeptuneObserver(api_token='YOUR_LONG_API_TOKEN',
+                                                project_name='USER_NAME/PROJECT_NAME'))
+
+        Run experiment::
+
+            @ex.config
+            def cfg():
+                C = 1.0
+                gamma = 0.7
+
+            @ex.automain
+            def run(C, gamma, _run):
+                iris = datasets.load_iris()
+                per = permutation(iris.target.size)
+                iris.data = iris.data[per]
+                iris.target = iris.target[per]
+                clf = svm.SVC(C, 'rbf', gamma=gamma)
+                clf.fit(iris.data[:90],
+                        iris.target[:90])
+                return clf.score(iris.data[90:],
+                                 iris.target[90:])
+
+        Go to the app and see the experiment. For example, https://ui.neptune.ml/jakub-czakon/examples/e/EX-263
+    """
+
+    def __init__(self, project_name, api_token=None, base_dir='.', source_extensions=None):
+        neptune.init(project_qualified_name=project_name, api_token=api_token)
+        self.resources = {}
+        self.base_dir = base_dir
+        if source_extensions:
+            self.source_extensions = source_extensions
+        else:
+            self.source_extensions = ['.py', '.R', '.cpp', '.yaml', '.yml']
+
+    def started_event(self, ex_info, command, host_info, start_time, config, meta_info, _id):
+
+        neptune.create_experiment(name=ex_info['name'],
+                                  params=_flatten_dict(config),
+                                  upload_source_files=_get_filepaths(dirpath=self.base_dir,
+                                                                     extensions=self.source_extensions),
+                                  properties={'mainfile': ex_info['mainfile'],
+                                              'dependencies': str(ex_info['dependencies']),
+                                              'sacred_id': str(_id),
+                                              **_str_dict_values(host_info),
+                                              **_str_dict_values(_flatten_dict(meta_info))})
+
+    def completed_event(self, stop_time, result):
+        if result:
+            neptune.log_metric('result', result)
+        neptune.stop()
+
+    def interrupted_event(self, interrupt_time, status):
+        neptune.stop()
+
+    def failed_event(self, fail_time, fail_trace):
+        neptune.stop()
+
+    def artifact_event(self, name, filename, metadata=None, content_type=None):
+        neptune.log_artifact(filename)
+
+    def resource_event(self, filename):
+        if filename not in self.resources:
+            new_prefix = self._create_new_prefix()
+            self.resources[filename] = new_prefix
+            md5 = get_digest(filename)
+
+            neptune.set_property('{}data_path'.format(new_prefix), filename)
+            neptune.set_property('{}data_version'.format(new_prefix), md5)
+
+    def log_metrics(self, metrics_by_name, info):
+        for metric_name, metric_ptr in metrics_by_name.items():
+            for step, value in zip(metric_ptr["steps"], metric_ptr["values"]):
+                neptune.log_metric(metric_name, x=step, y=value)
+
+    def _create_new_prefix(self):
+        existing_prefixes = self.resources.values()
+        if existing_prefixes:
+            prefix_ids = [int(prefix.replace('resource', '')) for prefix in existing_prefixes]
+            new_prefix = 'resource{}'.format(max(prefix_ids) + 1)
+        else:
+            new_prefix = 'resource0'
+        return new_prefix
+
+
+def _get_filepaths(dirpath, extensions):
+    files = []
+    for r, _, f in os.walk(dirpath):
+        for file in f:
+            if any(file.endswith(ext) for ext in extensions):
+                files.append(os.path.join(r, file))
+    return files
+
+
+def _flatten_dict(d, parent_key='', sep='_'):
+    items = []
+    for k, v in d.items():
+        new_key = parent_key + sep + k if parent_key else k
+        if isinstance(v, collections.MutableMapping):
+            items.extend(_flatten_dict(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)
+
+
+def _str_dict_values(d):
+    return {k: str(v) for k, v in d.items()}

--- a/sacred/observers/neptune_obs.py
+++ b/sacred/observers/neptune_obs.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# coding=utf-8
+
 import collections
 import os
 
@@ -17,6 +20,7 @@ class NeptuneObserver(RunObserver):
         project_name(str): project name in Neptune app
         api_token(str): Neptune API token. If it is kept in the NEPTUNE_API_TOKEN environment
            variable leave None here.
+        base_dir(str): base directory from which you run your code.
         source_extensions(list(str)): list of extensions that Neptune should treat as source files
            extensions and send.
 
@@ -31,7 +35,7 @@ class NeptuneObserver(RunObserver):
 
         Add Neptune observer::
 
-            from neptunecontrib.monitoring.sacred_integration import NeptuneObserver
+            from neptunecontrib.monitoring.sacred import NeptuneObserver
             ex.observers.append(NeptuneObserver(api_token='YOUR_LONG_API_TOKEN',
                                                 project_name='USER_NAME/PROJECT_NAME'))
 


### PR DESCRIPTION
Added integration via Observer with [neptune.ml](https://neptune.ml/) collaboration hub.

By adding an observer:

```python
from neptunecontrib.monitoring.sacred import NeptuneObserver
ex.observers.append(NeptuneObserver(project_name=USER_NAME/PROJECT_NAME'))
```

Users can have their metadata stored and backed-up in an online app and share it with collaborators.

Check [this example experiment](https://ui.neptune.ml/jakub-czakon/examples/e/EX-263/details) to see more.
![image](https://gist.githubusercontent.com/jakubczakon/f754769a39ea6b8fa9728ede49b9165c/raw/ae86f7321113327602be89c6ed3ac9d618ffdb4c/sacred_observer.png)
