### PR TITLE
Ensure waiting for observers

### DIFF
--- a/sacred/observers/queue.py
+++ b/sacred/observers/queue.py
@@ -61,6 +61,7 @@ class QueueObserver(RunObserver):
             )
 
     def _run(self):
+        """Empty the queue every interval."""
         while not self._queue.empty():
             try:
                 event = self._queue.get()
@@ -70,12 +71,10 @@ class QueueObserver(RunObserver):
                 pass
             else:
                 try:
-                    # method = getattr(self._covered_observer, event.name)
                     method = getattr(self._covered_observer, event.name)
                 except NameError:
-                    # covered observer does not implement event handler
-                    # for the event, so just
-                    # discard the message.
+                    # The covered observer does not implement an event handler
+                    # for the event, so just discard the message.
                     self._queue.task_done()
                 else:
                     while True:

--- a/sacred/run.py
+++ b/sacred/run.py
@@ -256,6 +256,7 @@ class Run:
             raise
         finally:
             self._warn_about_failed_observers()
+            self._wait_for_observers()
 
         return self.result
 

--- a/sacred/utils.py
+++ b/sacred/utils.py
@@ -749,8 +749,7 @@ class IntervalTimer(threading.Thread):
         return stop_event, timer_thread
 
     def __init__(self, event, func, interval=10.0):
-        # TODO use super here.
-        threading.Thread.__init__(self)
+        super().__init__()
         self.stopped = event
         self.func = func
         self.interval = interval

--- a/tests/test_observers/test_queue_mongo_observer.py
+++ b/tests/test_observers/test_queue_mongo_observer.py
@@ -118,7 +118,6 @@ def test_mongo_observer_completed_event_updates_run(mongo_obs, sample_run):
     mongo_obs.started_event(**sample_run)
 
     mongo_obs.completed_event(stop_time=T2, result=42)
-    mongo_obs.join()
 
     assert mongo_obs.runs.count() == 1
     db_run = mongo_obs.runs.find_one()
@@ -130,7 +129,6 @@ def test_mongo_observer_completed_event_updates_run(mongo_obs, sample_run):
 def test_mongo_observer_interrupted_event_updates_run(mongo_obs, sample_run):
     mongo_obs.started_event(**sample_run)
     mongo_obs.interrupted_event(interrupt_time=T2, status="INTERRUPTED")
-    mongo_obs.join()
 
     assert mongo_obs.runs.count() == 1
     db_run = mongo_obs.runs.find_one()
@@ -143,7 +141,6 @@ def test_mongo_observer_failed_event_updates_run(mongo_obs, sample_run):
 
     fail_trace = "lots of errors and\nso\non..."
     mongo_obs.failed_event(fail_time=T2, fail_trace=fail_trace)
-    mongo_obs.join()
 
     assert mongo_obs.runs.count() == 1
     db_run = mongo_obs.runs.find_one()


### PR DESCRIPTION
Even though the queue observer seems to be guaranteed to receive an event that calls `.join` it seems safer to ensure all observers are joined in the run itself.