### PR TITLE
Small patch to get around docopt bug.

### DIFF
--- a/sacred/commandline_options.py
+++ b/sacred/commandline_options.py
@@ -204,7 +204,7 @@ def debug_option(args, run):
     Set this run to debug mode.
 
     Suppress warnings about missing observers and don't filter the stacktrace.
-    Also enables usage with ipython --pdb.
+    Also enables usage with ipython `--pdb`.
     """
     run.debug = True
 


### PR DESCRIPTION
Fixes #634 . It's only a small fix, but to fix the real problem, we should drop docopt. See #637 