### PR TITLE
Fixed the futur circular imports.

### DIFF
--- a/sacred/commandline_options.py
+++ b/sacred/commandline_options.py
@@ -12,8 +12,7 @@ import re
 
 from sacred.run import Run
 from sacred.commands import print_config
-from sacred.settings import SETTINGS
-from sacred.utils import convert_camel_case_to_snake_case, get_inheritors
+from sacred.utils import convert_camel_case_to_snake_case
 
 
 CLIFunction = Callable[[str, Run], None]
@@ -171,27 +170,6 @@ def get_name(option):
         return option.get_name()
     else:
         return option.__name__
-
-
-def gather_command_line_options(filter_disabled=None):
-    """Get a sorted list of all CommandLineOption subclasses."""
-    if filter_disabled is None:
-        filter_disabled = not SETTINGS.COMMAND_LINE.SHOW_DISABLED_OPTIONS
-
-    options = []
-    for opt in get_inheritors(CommandLineOption):
-        warnings.warn(
-            "Subclassing `CommandLineOption` is deprecated. Please "
-            "use the `sacred.cli_option` decorator and pass the function "
-            "to the Experiment constructor."
-        )
-        if filter_disabled and not opt._enabled:
-            continue
-        options.append(opt)
-
-    options += DEFAULT_COMMAND_LINE_OPTIONS
-
-    return sorted(options, key=get_name)
 
 
 class HelpOption(CommandLineOption):
@@ -366,6 +344,3 @@ class CaptureOption(CommandLineOption):
     @classmethod
     def apply(cls, args, run):
         run.capture_mode = args
-
-
-DEFAULT_COMMAND_LINE_OPTIONS = [debug_option, loglevel_option]

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -2,17 +2,21 @@
 import inspect
 import os.path
 import sys
+import warnings
 from collections import OrderedDict
 from typing import Sequence, Optional, List
 
 from docopt import docopt, printable_usage
 
+from sacred import SETTINGS
 from sacred.arg_parser import format_usage, get_config_updates
 from sacred.commandline_options import (
     ForceOption,
-    gather_command_line_options,
     loglevel_option,
     CLIOption,
+    debug_option,
+    CommandLineOption,
+    get_name,
 )
 from sacred.commands import (
     help_for_command,
@@ -32,6 +36,7 @@ from sacred.utils import (
     SacredError,
     format_sacred_error,
     PathType,
+    get_inheritors,
 )
 
 __all__ = ("Experiment",)
@@ -553,3 +558,27 @@ class Experiment(Ingredient):
                 print(help_for_command(commands[args["COMMAND"]]))
                 return True
         return False
+
+
+def gather_command_line_options(filter_disabled=None):
+    """Get a sorted list of all CommandLineOption subclasses."""
+    if filter_disabled is None:
+        filter_disabled = not SETTINGS.COMMAND_LINE.SHOW_DISABLED_OPTIONS
+
+    options = []
+    for opt in get_inheritors(CommandLineOption):
+        warnings.warn(
+            "Subclassing `CommandLineOption` is deprecated. Please "
+            "use the `sacred.cli_option` decorator and pass the function "
+            "to the Experiment constructor."
+        )
+        if filter_disabled and not opt._enabled:
+            continue
+        options.append(opt)
+
+    options += DEFAULT_COMMAND_LINE_OPTIONS
+
+    return sorted(options, key=get_name)
+
+
+DEFAULT_COMMAND_LINE_OPTIONS = [debug_option, loglevel_option]

--- a/tests/test_arg_parser.py
+++ b/tests/test_arg_parser.py
@@ -7,7 +7,7 @@ import shlex
 from docopt import docopt
 
 from sacred.arg_parser import _convert_value, get_config_updates, format_usage
-from sacred.commandline_options import gather_command_line_options
+from sacred.experiment import gather_command_line_options
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When adding the command line options for the observers in the list of default command line options, it creates a circular import. This fixes it.