### PR TITLE
Fixing the silent overwritting of important files.

### DIFF
--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -195,7 +195,16 @@ class FileStorageObserver(RunObserver):
 
     def save_file(self, filename, target_name=None):
         target_name = target_name or os.path.basename(filename)
-        copyfile(filename, os.path.join(self.dir, target_name))
+        blacklist = ["run.json", "config.json", "cout.txt", "metrics.json"]
+        blacklist = [os.path.join(self.dir, x) for x in blacklist]
+        dest_file = os.path.join(self.dir, target_name)
+        if dest_file in blacklist:
+            raise FileExistsError(
+                "You are trying to overwrite a file necessary for the "
+                "FileStorageObserver. "
+                "The list of blacklisted files is: {}".format(blacklist)
+            )
+        copyfile(filename, dest_file)
 
     def save_cout(self):
         with open(os.path.join(self.dir, "cout.txt"), "ab") as f:

--- a/tests/test_observers/test_file_storage_observer.py
+++ b/tests/test_observers/test_file_storage_observer.py
@@ -8,6 +8,7 @@ import tempfile
 from copy import copy
 import pytest
 import json
+from pathlib import Path
 
 from sacred.observers.file_storage import FileStorageObserver
 from sacred.metrics_logger import ScalarMetricLogEntry, linearize_metrics
@@ -426,3 +427,12 @@ def test_observer_equality(tmpdir):
     observer_3 = FileStorageObserver(str(tmpdir / "a"))
     assert observer_1 == observer_3
     assert observer_1 != observer_2
+
+
+def test_blacklist_paths(tmpdir, dir_obs, sample_run):
+    basedir, obs = dir_obs
+    obs.started_event(**sample_run)
+    other_file = Path(tmpdir / "dodo.txt")
+    other_file.touch()
+    with pytest.raises(FileExistsError):
+        obs.save_file(str(other_file), "cout.txt")

--- a/tests/test_observers/test_file_storage_observer.py
+++ b/tests/test_observers/test_file_storage_observer.py
@@ -432,7 +432,7 @@ def test_observer_equality(tmpdir):
 def test_blacklist_paths(tmpdir, dir_obs, sample_run):
     basedir, obs = dir_obs
     obs.started_event(**sample_run)
-    other_file = Path(tmpdir / "dodo.txt")
+    other_file = Path(str(tmpdir / "dodo.txt"))
     other_file.touch()
     with pytest.raises(FileExistsError):
         obs.save_file(str(other_file), "cout.txt")


### PR DESCRIPTION
Fixes #596 

For the `exist_ok` argument, we can see later on.