### PR TITLE
More info to contribute.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -100,6 +100,7 @@ local development.
 
     $ # Activate your environment
     $ pip install -e .
+    $ pip install -r dev-requirements.txt
     $ pre-commit install
 
 You can check that pre-commit works with::

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -122,7 +122,7 @@ Now you can make your changes locally.
 
     $ tox
 
-To get tox, use ``pip install tox`` or ``conda install conda-tox``.
+To get tox, use ``pip install tox`` or ``pip install tox-conda``. If you have a conda distribution, you MUST use tox-conda.
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -99,8 +99,20 @@ local development.
 4. Create your development environment and install the pre-commit hooks::
 
     $ # Activate your environment
-    $ pip install -r dev-requirements.txt
+    $ pip install -e .
     $ pre-commit install
+
+You can check that pre-commit works with::
+
+    $ pre-commit run --all-files
+
+if you get the error ``ModuleNotFoundError: No module named 'distutils.spawn'``,
+you should do the following::
+
+    $ sudo apt-get update
+    $ sudo apt-get install python3-distutils
+
+It should solve the problem with ``distutils.spawn``.
 
 Now you can make your changes locally.
 
@@ -109,7 +121,7 @@ Now you can make your changes locally.
 
     $ tox
 
-To get tox, just pip install it.
+To get tox, use ``pip install tox`` or ``conda install conda-tox``.
 
 6. Commit your changes and push your branch to GitHub::
 


### PR DESCRIPTION
the `-e .` is better than just installing the dev-requirements.txt because sacred will then be registered as a python package in editable mode, so usable from anywhere on your computer.

Also, users using conda shouldn't do `pip install tox` as it won't work.