### PR TITLE
Notification

### DIFF
--- a/examples/notification.py
+++ b/examples/notification.py
@@ -1,0 +1,17 @@
+from notif.notificator import SlackNotificator
+
+import sacred
+
+ex = sacred.Experiment('deep-address-tagger')
+
+notificator = SlackNotificator(
+    webhook_url="webhook_url_to_throw_notification")
+# Change for a valid webhook url. Read the doc about Slack webhook for information on how to get one.
+
+ex.add_notificator(notificator=notificator)
+
+
+@ex.automain
+def main():
+    print('3')
+    # This will also throw a message into your Slack channel.

--- a/examples/notification.py
+++ b/examples/notification.py
@@ -2,10 +2,9 @@ from notif.notificator import SlackNotificator
 
 import sacred
 
-ex = sacred.Experiment('deep-address-tagger')
+ex = sacred.Experiment("deep-address-tagger")
 
-notificator = SlackNotificator(
-    webhook_url="webhook_url_to_throw_notification")
+notificator = SlackNotificator(webhook_url="webhook_url_to_throw_notification")
 # Change for a valid webhook url. Read the doc about Slack webhook for information on how to get one.
 
 ex.add_notificator(notificator=notificator)
@@ -13,5 +12,5 @@ ex.add_notificator(notificator=notificator)
 
 @ex.automain
 def main():
-    print('3')
+    print("3")
     # This will also throw a message into your Slack channel.

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -342,6 +342,11 @@ class Experiment(Ingredient):
                     print(format_sacred_error(e, short_usage), file=sys.stderr)
                 else:
                     print_filtered_stacktrace()
+
+                # Handle the push of a notification threw a notificator
+                if self.notificator is not None:
+                    self.notificator.send_notification_error(error=e)
+
                 sys.exit(1)
 
     def open_resource(self, filename: PathType, mode: str = "r"):

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -272,9 +272,10 @@ class Experiment(Ingredient):
         )
         run()
 
+        # If a notificator is present we throw a notification threw it.
         if self.notificator is not None:
             self.notificator.send_notification(message="Job %s is done.".format(self.path))
-            
+
         return run
 
     def run_commandline(self, argv=None) -> Optional[Run]:

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -274,7 +274,7 @@ class Experiment(Ingredient):
 
         # If a notificator is present we throw a notification threw it.
         if self.notificator is not None:
-            self.notificator.send_notification(message="Job %s is done.".format(self.path))
+            self.notificator.send_notification(message="Job {} is done.".format(self.path))
 
         return run
 

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -274,7 +274,9 @@ class Experiment(Ingredient):
 
         # If a notificator is present we throw a notification threw it.
         if self.notificator is not None:
-            self.notificator.send_notification(message="Job {} is done.".format(self.path))
+            self.notificator.send_notification(
+                message="Job {} is done.".format(self.path)
+            )
 
         return run
 

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -271,6 +271,10 @@ class Experiment(Ingredient):
             command_name, config_updates, named_configs, info, meta_info, options
         )
         run()
+
+        if self.notificator is not None:
+            self.notificator.send_notification(message="Job %s is done.".format(self.path))
+            
         return run
 
     def run_commandline(self, argv=None) -> Optional[Run]:

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -295,7 +295,7 @@ class Ingredient:
             raise ValueError('Invalid Version: "{}"'.format(version))
         self.dependencies.add(PackageDependency(package_name, version))
 
-    def add_notificator(self, notificator) -> None:
+    def add_notificator(self, notificator):
         """
         Add a notificator to this ingredient/experiment.
 

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -295,7 +295,7 @@ class Ingredient:
             raise ValueError('Invalid Version: "{}"'.format(version))
         self.dependencies.add(PackageDependency(package_name, version))
 
-    def add_notificator(self, notificator):
+    def add_notificator(self, notificator) -> None:
         """
         Add a notificator to this ingredient/experiment.
 
@@ -303,6 +303,7 @@ class Ingredient:
         See `notif <https://github.com/davebulaval/notification>` package for example and already defined notificator.
 
         :param notificator: Notificator to push notification when experiment is finish or when experiment have fail.
+        :type notificator
         """
         self.notificator = notificator
 

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -299,7 +299,8 @@ class Ingredient:
         """
         Add a notificator to this ingredient/experiment.
 
-        Can be called with any notificator which implement a send_notification_error method. See `notif <https://github.com/davebulaval/notification>` package for example.
+        Can be called with any notificator which implement a send_notification_error and send_notification methods.
+        See `notif <https://github.com/davebulaval/notification>` package for example and already defined notificator.
 
         :param notificator: Notificator to push notification when experiment is finish or when experiment have fail.
         """

--- a/sacred/ingredient.py
+++ b/sacred/ingredient.py
@@ -83,6 +83,8 @@ class Ingredient:
                 " want to run it pass interactive=True"
             )
 
+        self.notificator = None
+
     # =========================== Decorators ==================================
     @optional_kwargs_decorator
     def capture(self, function=None, prefix=None):
@@ -292,6 +294,16 @@ class Ingredient:
         if not PEP440_VERSION_PATTERN.match(version):
             raise ValueError('Invalid Version: "{}"'.format(version))
         self.dependencies.add(PackageDependency(package_name, version))
+
+    def add_notificator(self, notificator):
+        """
+        Add a notificator to this ingredient/experiment.
+
+        Can be called with any notificator which implement a send_notification_error method. See `notif <https://github.com/davebulaval/notification>` package for example.
+
+        :param notificator: Notificator to push notification when experiment is finish or when experiment have fail.
+        """
+        self.notificator = notificator
 
     def post_process_name(self, name, ingredient):
         """Can be overridden to change the command name."""

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
+from unittest.mock import Mock
 
 from sacred import Ingredient
 
@@ -34,7 +35,6 @@ def test_automain_imported(ex):
     main_called = [False]
 
     with patch.object(sys, "argv", ["test.py"]):
-
         @ex.automain
         def foo():
             main_called[0] = True
@@ -270,7 +270,6 @@ def test_adding_option_hooks(ex):
 
 def test_option_hooks_without_options_arg_raises(ex):
     with pytest.raises(KeyError):
-
         @ex.option_hook
         def invalid_hook(wrong_arg_name):
             pass
@@ -427,7 +426,6 @@ def test_additional_gatherers():
 
 @pytest.mark.parametrize("command_line_option", ["-w", "--warning"])
 def test_additional_cli_options_flag(command_line_option):
-
     executed = [False]
 
     @cli_option("-w", "--warning", is_flag=True)
@@ -446,7 +444,6 @@ def test_additional_cli_options_flag(command_line_option):
 
 @pytest.mark.parametrize("command_line_option", ["-w", "--warning"])
 def test_additional_cli_options(command_line_option):
-
     executed = [False]
 
     @cli_option("-w", "--warning")
@@ -461,3 +458,27 @@ def test_additional_cli_options(command_line_option):
 
     experiment.run_commandline([__file__, command_line_option, "10"])
     assert executed[0] == "10"
+
+
+def test_experiment_done_call_notificator(ex):
+    mocked_notificator = Mock(webhook_url="fake_url")
+    mocked_notificator.send_notification('fake_message')
+    ex.add_notificator(mocked_notificator)
+
+    @ex.main
+    def foo():
+        pass
+
+    mocked_notificator.send_notification.assert_called()
+
+def test_experiment_fail_call_notificator(ex):
+    mocked_notificator = Mock(webhook_url="fake_url")
+    mocked_notificator.send_notification("fake_message")
+    mocked_notificator.send_notification_error('fake_error')
+    ex.add_notificator(mocked_notificator)
+
+    @ex.main
+    def foo():
+        print(t)
+
+    mocked_notificator.send_notification_error.assert_called()

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -462,24 +462,23 @@ def test_additional_cli_options(command_line_option):
 
 def test_experiment_done_call_notificator(ex):
     mocked_notificator = Mock(webhook_url="fake_url")
-    mocked_notificator.send_notification('fake_message')
+    mocked_notificator.send_notification()
     ex.add_notificator(mocked_notificator)
 
     @ex.main
     def foo():
         pass
 
-    mocked_notificator.send_notification.assert_called()
+    mocked_notificator.send_notification.assert_called_with()
 
 
 def test_experiment_fail_call_notificator(ex):
     mocked_notificator = Mock(webhook_url="fake_url")
-    mocked_notificator.send_notification("fake_message")
-    mocked_notificator.send_notification_error('fake_error')
+    mocked_notificator.send_notification_error()
     ex.add_notificator(mocked_notificator)
 
     @ex.main
     def foo():
         print(t)
 
-    mocked_notificator.send_notification_error.assert_called()
+    mocked_notificator.send_notification_error.assert_called_with()

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -35,6 +35,7 @@ def test_automain_imported(ex):
     main_called = [False]
 
     with patch.object(sys, "argv", ["test.py"]):
+
         @ex.automain
         def foo():
             main_called[0] = True
@@ -270,6 +271,7 @@ def test_adding_option_hooks(ex):
 
 def test_option_hooks_without_options_arg_raises(ex):
     with pytest.raises(KeyError):
+
         @ex.option_hook
         def invalid_hook(wrong_arg_name):
             pass

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -471,6 +471,7 @@ def test_experiment_done_call_notificator(ex):
 
     mocked_notificator.send_notification.assert_called()
 
+
 def test_experiment_fail_call_notificator(ex):
     mocked_notificator = Mock(webhook_url="fake_url")
     mocked_notificator.send_notification("fake_message")


### PR DESCRIPTION
# Added implementation of notification threw a notificator.

Ingredient now have a notificator attribute and his added with the add_notificator method. (documented)

This allow to push a notification (like a Slack message, a Facebook messenger message or else) when the script is failling or when the job is done.

> I've worked on implementation of notificator with my [notif](https://github.com/davebulaval/notification) package, but was not sure if adding dependancies was the appropriated approach. So one can simply use the notif package or any other class which implement send_notification_error and send_notification method.

The motivation of this PR  is to have notification when a script is failling or when the script is done.

Since I was not sure about your commenting approach, i've place comment where code have been added. Feel free to remove it since I think code is pretty clear without the comment.

Also, I added a code example on how to use the notificator. But since to fully work you need a valid webhook url, the example is not _working_ (one cann't execute the script). Also, I was not sure where (and if) it would be appropriated to mention it in the documentation. Any ideas ?

## Testing
I have added two test to verify if the notificator are called when needed and present. Since the notificator are throwing message, i've mocked the notificator.

