### PR TITLE
Specify utf-8 encoding in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ setup(
     tests_require=["mock>=0.8, <3.0", "pytest==4.3.0"],
     classifiers=list(filter(None, classifiers.split("\n"))),
     description="Facilitates automated and reproducible experimental research",
-    long_description=Path("README.rst").read_text(encoding='utf-8'),
+    long_description=Path("README.rst").read_text(encoding="utf-8"),
 )

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ setup(
     tests_require=["mock>=0.8, <3.0", "pytest==4.3.0"],
     classifiers=list(filter(None, classifiers.split("\n"))),
     description="Facilitates automated and reproducible experimental research",
-    long_description=Path("README.rst").read_text(),
+    long_description=Path("README.rst").read_text(encoding='utf-8'),
 )


### PR DESCRIPTION
On some versions of Windows (those with other than utf-8 default encoding) pip install fails because of the encoding error. Solution is to explicitly specify utf-8 encoding.