### PR TITLE
Update black to stable version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 fail_fast: true
 repos:
 -   repo: https://github.com/psf/black
-    rev: master
+    rev: stable
     hooks:
     - id: black
       language_version: python3.6

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -558,8 +558,9 @@ class Experiment(Ingredient):
     def _check_command(self, cmd_name):
         commands = dict(self.gather_commands())
         if cmd_name is not None and cmd_name not in commands:
-            return 'Error: Command "{}" not found. Available commands are: ' "{}".format(
-                cmd_name, ", ".join(commands.keys())
+            return (
+                'Error: Command "{}" not found. Available commands are: '
+                "{}".format(cmd_name, ", ".join(commands.keys()))
             )
 
         if cmd_name is None:

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,8 @@ commands =
 
 [testenv:black]
 basepython = python
-deps = git+https://github.com/psf/black
+deps = 
+    black==19.10b0
 commands = 
     black --check sacred/ tests/
 


### PR DESCRIPTION
Now that the new version is released, stable can be used without introducing py35 incompatibilities.