### PR TITLE
fix reading of readme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # coding=utf-8
 
 from pathlib import Path
+import codecs
 
 from setuptools import setup
 
@@ -43,5 +44,5 @@ setup(
     tests_require=["mock>=0.8, <3.0", "pytest==4.3.0"],
     classifiers=list(filter(None, classifiers.split("\n"))),
     description="Facilitates automated and reproducible experimental research",
-    long_description=Path("README.rst").read_text(encoding="utf-8"),
+    long_description=codecs.open("README.rst", "r", encoding="utf-8").read(),
 )


### PR DESCRIPTION
On some environments, the setup.py is unable to complete due to encoding
issues. Use vanialla python open() to rely on the python encoding abilities.

    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-986m_f7j/sacred/setup.py", line 46, in <module>
        long_description=Path("README.rst").read_text(),
      File "/usr/lib/python3.6/pathlib.py", line 1197, in read_text
        return f.read()
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 10799: ordinal not in range(128)