### PR TITLE
add support for trailing comments in config scope definition.

### DIFF
--- a/sacred/config/config_scope.py
+++ b/sacred/config/config_scope.py
@@ -95,7 +95,7 @@ def get_function_body(func):
     arg = "(?:[a-zA-Z_][a-zA-Z0-9_]*)"
     arguments = r"{0}(?:\s*,\s*{0})*".format(arg)
     func_def = re.compile(
-        r"^[ \t]*def[ \t]*{}[ \t]*\(\s*({})?\s*\)[ \t]*:[ \t]*\n".format(
+        r"^[ \t]*def[ \t]*{}[ \t]*\(\s*({})?\s*\)[ \t]*:[ \t]*(?:#[^\n]*)?\n".format(
             func.__name__, arguments
         ),
         flags=re.MULTILINE,

--- a/tests/test_config/test_config_scope.py
+++ b/tests/test_config/test_config_scope.py
@@ -293,7 +293,7 @@ def test_is_empty_or_comment(line, expected):
 
 def evil_indentation_func(a,
                                     b,
-c, d):
+c, d):  # test comment
 # Lets do the most evil things with indentation
   # 1
     # 2


### PR DESCRIPTION
fixes #698