### PR TITLE
Add option to pass a collection prefix to MongoObserver

### DIFF
--- a/sacred/observers/mongo.py
+++ b/sacred/observers/mongo.py
@@ -143,11 +143,16 @@ class MongoObserver(RunObserver):
         runs_collection_name = '{}runs'.format(collection_prefix)
         metrics_collection_name = '{}metrics'.format(collection_prefix)
 
-        if runs_collection_name in MongoObserver.COLLECTION_NAME_BLACKLIST or \
-           metrics_collection_name in MongoObserver.COLLECTION_NAME_BLACKLIST:
+        if runs_collection_name in MongoObserver.COLLECTION_NAME_BLACKLIST:
             raise KeyError(
                 'Collection name "{}" is reserved. '
-                "Please use a different one.".format(collection)
+                "Please use a different one.".format(runs_collection_name)
+            )
+
+        if metrics_collection_name in MongoObserver.COLLECTION_NAME_BLACKLIST:
+            raise KeyError(
+                'Collection name "{}" is reserved. '
+                "Please use a different one.".format(metrics_collection_name)
             )
 
         runs_collection = database[runs_collection_name]

--- a/sacred/observers/mongo.py
+++ b/sacred/observers/mongo.py
@@ -127,26 +127,25 @@ class MongoObserver(RunObserver):
             client = pymongo.MongoClient(url, **kwargs)
 
         database = client[db_name]
-        if collection != 'runs':
+        if collection != "runs":
             # the 'old' way of setting a custom collection name
             # still works as before for backward compatibility
             warnings.warn(
                 'Argument "collection" is deprecated. '
                 'Please use "collection_prefix" instead.',
-                DeprecationWarning)
+                DeprecationWarning,
+            )
             if collection_prefix != "":
-                raise ValueError(
-                    'Cannot pass both collection and a collection prefix.'
-                )
+                raise ValueError("Cannot pass both collection and a collection prefix.")
             runs_collection_name = collection
-            metrics_collection_name = 'metrics'
+            metrics_collection_name = "metrics"
         else:
             if collection_prefix != "":
                 # separate prefix from 'runs' / 'collections' by an underscore.
-                collection_prefix = '{}_'.format(collection_prefix)
+                collection_prefix = "{}_".format(collection_prefix)
 
-            runs_collection_name = '{}runs'.format(collection_prefix)
-            metrics_collection_name = '{}metrics'.format(collection_prefix)
+            runs_collection_name = "{}runs".format(collection_prefix)
+            metrics_collection_name = "{}metrics".format(collection_prefix)
 
         if runs_collection_name in MongoObserver.COLLECTION_NAME_BLACKLIST:
             raise KeyError(

--- a/sacred/observers/mongo.py
+++ b/sacred/observers/mongo.py
@@ -125,8 +125,11 @@ class MongoObserver(RunObserver):
                 raise ValueError("Cannot pass both a client and a url.")
         else:
             client = pymongo.MongoClient(url, **kwargs)
+
         database = client[db_name]
         if collection != 'runs':
+            # the 'old' way of setting a custom collection name
+            # still works as before for backward compatibility
             warnings.warn(
                 'Argument "collection" is deprecated. '
                 'Please use "collection_prefix" instead.',
@@ -135,13 +138,15 @@ class MongoObserver(RunObserver):
                 raise ValueError(
                     'Cannot pass both collection and a collection prefix.'
                 )
+            runs_collection_name = collection
+            metrics_collection_name = 'metrics'
+        else:
+            if collection_prefix != "":
+                # separate prefix from 'runs' / 'collections' by an underscore.
+                collection_prefix = '{}_'.format(collection_prefix)
 
-        if collection_prefix != "":
-            # separate prefix from 'runs' / 'collections' by an underscore.
-            collection_prefix = '{}_'.format(collection_prefix)
-
-        runs_collection_name = '{}runs'.format(collection_prefix)
-        metrics_collection_name = '{}metrics'.format(collection_prefix)
+            runs_collection_name = '{}runs'.format(collection_prefix)
+            metrics_collection_name = '{}metrics'.format(collection_prefix)
 
         if runs_collection_name in MongoObserver.COLLECTION_NAME_BLACKLIST:
             raise KeyError(

--- a/sacred/observers/mongo.py
+++ b/sacred/observers/mongo.py
@@ -126,11 +126,6 @@ class MongoObserver(RunObserver):
         else:
             client = pymongo.MongoClient(url, **kwargs)
         database = client[db_name]
-        if collection in MongoObserver.COLLECTION_NAME_BLACKLIST:
-            raise KeyError(
-                'Collection name "{}" is reserved. '
-                "Please use a different one.".format(collection)
-            )
         if collection != 'runs':
             warnings.warn(
                 'Argument "collection" is deprecated. '
@@ -147,6 +142,14 @@ class MongoObserver(RunObserver):
 
         runs_collection_name = '{}runs'.format(collection_prefix)
         metrics_collection_name = '{}metrics'.format(collection_prefix)
+
+        if runs_collection_name in MongoObserver.COLLECTION_NAME_BLACKLIST or \
+           metrics_collection_name in MongoObserver.COLLECTION_NAME_BLACKLIST:
+            raise KeyError(
+                'Collection name "{}" is reserved. '
+                "Please use a different one.".format(collection)
+            )
+
         runs_collection = database[runs_collection_name]
         metrics_collection = database[metrics_collection_name]
         fs = gridfs.GridFS(database)

--- a/tests/test_observers/test_mongo_observer.py
+++ b/tests/test_observers/test_mongo_observer.py
@@ -38,9 +38,14 @@ def test_create_should_raise_error_on_both_client_and_url():
 
 def test_create_should_raise_error_on_both_prefix_and_runs():
     real_client = pymongo.MongoClient()
-    with pytest.raises(ValueError, match="Cannot pass both collection and a collection prefix."):
-        MongoObserver(client=real_client, collection_prefix='myprefix',
-                      collection='some_collection')
+    with pytest.raises(
+        ValueError, match="Cannot pass both collection and a collection prefix."
+    ):
+        MongoObserver(
+            client=real_client,
+            collection_prefix="myprefix",
+            collection="some_collection",
+        )
 
 
 @pytest.fixture
@@ -56,7 +61,7 @@ def mongo_obs():
 def mongo_obs_with_prefix():
     # create a mongo observer with a collection prefix
     real_client = pymongo.MongoClient()
-    return MongoObserver(collection_prefix='testing', client=real_client)
+    return MongoObserver(collection_prefix="testing", client=real_client)
 
 
 @pytest.fixture
@@ -72,7 +77,7 @@ def mongo_obs_with_collection():
     # old, deprecated way of creating a mongo observer
     # should use 'my_collection' for runs and 'metrics' for metrics
     real_client = pymongo.MongoClient()
-    return MongoObserver(client=real_client, collection='my_collection')
+    return MongoObserver(client=real_client, collection="my_collection")
 
 
 @pytest.fixture
@@ -469,24 +474,24 @@ def test_mongo_observer_artifact_event_metadata(mongo_obs, sample_run):
 
 
 def test_mongo_observer_created_with_prefix(mongo_obs_with_prefix):
-    print('with_prefix_test')
+    print("with_prefix_test")
     runs_collection = mongo_obs_with_prefix.runs
     metrics_collection = mongo_obs_with_prefix.metrics
-    assert runs_collection.name == 'testing_runs'
-    assert metrics_collection.name == 'testing_metrics'
+    assert runs_collection.name == "testing_runs"
+    assert metrics_collection.name == "testing_metrics"
 
 
 def test_mongo_observer_created_without_prefix(mongo_obs_without_prefix):
-    print('without_prefix_test')
+    print("without_prefix_test")
     runs_collection = mongo_obs_without_prefix.runs
     metrics_collection = mongo_obs_without_prefix.metrics
-    assert runs_collection.name == 'runs'
-    assert metrics_collection.name == 'metrics'
+    assert runs_collection.name == "runs"
+    assert metrics_collection.name == "metrics"
 
 
 def test_mongo_observer_created_with_collection(mongo_obs_with_collection):
-    print('with_collection_test')
+    print("with_collection_test")
     runs_collection = mongo_obs_with_collection.runs
     metrics_collection = mongo_obs_with_collection.metrics
-    assert runs_collection.name == 'my_collection'
-    assert metrics_collection.name == 'metrics'
+    assert runs_collection.name == "my_collection"
+    assert metrics_collection.name == "metrics"

--- a/tests/test_observers/test_mongo_observer.py
+++ b/tests/test_observers/test_mongo_observer.py
@@ -36,6 +36,13 @@ def test_create_should_raise_error_on_both_client_and_url():
         MongoObserver(client=real_client, url="mymongourl")
 
 
+def test_create_should_raise_error_on_both_prefix_and_runs():
+    real_client = pymongo.MongoClient()
+    with pytest.raises(ValueError, match="Cannot pass both collection and a collection prefix."):
+        MongoObserver(client=real_client, collection_prefix='myprefix',
+                      collection='some_collection')
+
+
 @pytest.fixture
 def mongo_obs():
     db = mongomock.MongoClient().db
@@ -43,6 +50,29 @@ def mongo_obs():
     metrics = db.metrics
     fs = gridfs.GridFS(db)
     return MongoObserver.create_from(runs, fs, metrics_collection=metrics)
+
+
+@pytest.fixture
+def mongo_obs_with_prefix():
+    # create a mongo observer with a collection prefix
+    real_client = pymongo.MongoClient()
+    return MongoObserver(collection_prefix='testing', client=real_client)
+
+
+@pytest.fixture
+def mongo_obs_without_prefix():
+    # create a mongo observer without a collection prefix
+    # i.e. should default to collections 'runs' and 'metrics'
+    real_client = pymongo.MongoClient()
+    return MongoObserver(client=real_client)
+
+
+@pytest.fixture
+def mongo_obs_with_collection():
+    # old, deprecated way of creating a mongo observer
+    # should use 'my_collection' for runs and 'metrics' for metrics
+    real_client = pymongo.MongoClient()
+    return MongoObserver(client=real_client, collection='my_collection')
 
 
 @pytest.fixture
@@ -436,3 +466,27 @@ def test_mongo_observer_artifact_event_metadata(mongo_obs, sample_run):
 
     db_run = mongo_obs.runs.find_one()
     assert db_run["artifacts"]
+
+
+def test_mongo_observer_created_with_prefix(mongo_obs_with_prefix):
+    print('with_prefix_test')
+    runs_collection = mongo_obs_with_prefix.runs
+    metrics_collection = mongo_obs_with_prefix.metrics
+    assert runs_collection.name == 'testing_runs'
+    assert metrics_collection.name == 'testing_metrics'
+
+
+def test_mongo_observer_created_without_prefix(mongo_obs_without_prefix):
+    print('without_prefix_test')
+    runs_collection = mongo_obs_without_prefix.runs
+    metrics_collection = mongo_obs_without_prefix.metrics
+    assert runs_collection.name == 'runs'
+    assert metrics_collection.name == 'metrics'
+
+
+def test_mongo_observer_created_with_collection(mongo_obs_with_collection):
+    print('with_collection_test')
+    runs_collection = mongo_obs_with_collection.runs
+    metrics_collection = mongo_obs_with_collection.metrics
+    assert runs_collection.name == 'my_collection'
+    assert metrics_collection.name == 'metrics'


### PR DESCRIPTION
See issue #700. 

* Added a new argument `collection_prefix` to the constructor MongoObserver.
* Runs will be stored in collection `f'{collection_prefix}_runs'` (or `runs` if no prefix provided) 
* Metrics will be stored in collection `f'{collection_prefix}_metrics'` (or `metrics` if no prefix provided) 
* Argument `collection` is now deprecated in favor of `collection_prefix`.
* Name blacklist checks are currently obsolete because there is no way to come up with a name from the blacklist using a prefix. Nevertheless I kept them in case the blacklist changes at some point.

Let me know if there's anything else I could/should do :)