### PR TITLE
Do not convert carriage returns to newlines in captured output

### DIFF
--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -192,6 +192,7 @@ class FileStorageObserver(RunObserver):
     def save_json(self, obj, filename):
         with open(os.path.join(self.dir, filename), "w") as f:
             json.dump(flatten(obj), f, sort_keys=True, indent=2)
+            f.flush()
 
     def save_file(self, filename, target_name=None):
         target_name = target_name or os.path.basename(filename)

--- a/sacred/stdout_capturing.py
+++ b/sacred/stdout_capturing.py
@@ -116,7 +116,7 @@ def tee_output_python():
 @contextmanager
 def tee_output_fd():
     """Duplicate stdout and stderr to a file on the file descriptor level."""
-    with NamedTemporaryFile(mode="w+") as target:
+    with NamedTemporaryFile(mode="w+", newline="") as target:
         original_stdout_fd = 1
         original_stderr_fd = 2
         target_fd = target.fileno()

--- a/sacred/stdout_capturing.py
+++ b/sacred/stdout_capturing.py
@@ -116,12 +116,14 @@ def tee_output_python():
 @contextmanager
 def tee_output_fd():
     """Duplicate stdout and stderr to a file on the file descriptor level."""
-    with NamedTemporaryFile(mode="w+", newline="") as target:
+    get_temp_file = lambda: NamedTemporaryFile(mode="w+", newline="") \
+        if sys.version_info >= (3,) else NamedTemporaryFile(mode="w+")
+    with get_temp_file() as target:
         original_stdout_fd = 1
         original_stderr_fd = 2
         target_fd = target.fileno()
 
-        # Save a copy of the original stdout and stderr file descriptors
+        # Save a copy of the original stdout and stderr file descriptors)
         saved_stdout_fd = os.dup(original_stdout_fd)
         saved_stderr_fd = os.dup(original_stderr_fd)
 

--- a/tests/test_stdout_capturing.py
+++ b/tests/test_stdout_capturing.py
@@ -33,6 +33,7 @@ def test_fd_tee_output(capsys):
         "captured stderr",
         "stdout from C",
         "and this is from echo",
+        "keep\rcarriage\rreturns",
     }
 
     capture_mode, capture_stdout = get_stdcapturer("fd")
@@ -43,6 +44,7 @@ def test_fd_tee_output(capsys):
         with capture_stdout() as out:
             print("captured stdout")
             print("captured stderr", file=sys.stderr)
+            print("keep\rcarriage\rreturns")
             output += out.get()
             libc.puts(b"stdout from C")
             libc.fflush(None)


### PR DESCRIPTION
Fix for [Issue 673](https://github.com/IDSIA/sacred/issues/673), in which carriage returns are being converted to new lines in Python 3.

A test has been added. In Python 3, this test fails prior to this fix, and passes after this fix is introduced.