### PR TITLE
Terminate tee subprocesses before waiting

### DIFF
--- a/sacred/stdout_capturing.py
+++ b/sacred/stdout_capturing.py
@@ -172,6 +172,10 @@ def tee_output_fd():
             os.dup2(saved_stdout_fd, original_stdout_fd)
             os.dup2(saved_stderr_fd, original_stderr_fd)
 
+            # terminate both subprocesses to avoid timeout errors below
+            tee_stdout.terminate()
+            tee_stderr.terminate()
+
             tee_stdout.wait(timeout=1)
             tee_stderr.wait(timeout=1)
 


### PR DESCRIPTION
Send termination signals to `tee_stdout` and `tee_stderr`, before waiting.
This is needed because on some systems there seems to be deadlock issues related to using multiprocessing combined with fd capture. #705 (comment) shows an example of this.

This change reliably fixes the problem on the system I am using, and hopefully for others as well. There should be no ill effects from terminating the subprocesses because this is done after the
stdin pipe is closed.

Fixes #705