### PR TITLE
Fix ConfigError tracking when raised in config scope

### DIFF
--- a/sacred/config/captured_function.py
+++ b/sacred/config/captured_function.py
@@ -38,7 +38,7 @@ def captured_function(wrapped, instance, args, kwargs):
         wrapped.logger.debug("Started")
         start_time = time.time()
     # =================== run actual function =================================
-    with ConfigError.track(wrapped):
+    with ConfigError.track(wrapped.config, wrapped.prefix):
         result = wrapped(*args, **kwargs)
     # =========================================================================
     if wrapped.logger is not None:

--- a/sacred/config/config_scope.py
+++ b/sacred/config/config_scope.py
@@ -12,6 +12,7 @@ from sacred import SETTINGS
 from sacred.config.config_summary import ConfigSummary
 from sacred.config.utils import dogmatize, normalize_or_die, recursive_fill_in
 from sacred.config.signature import get_argspec
+from sacred.utils import ConfigError
 
 
 class ConfigScope:
@@ -68,7 +69,9 @@ class ConfigScope:
                 fallback_view[arg] = fallback[arg]
 
         cfg_locals.fallback = fallback_view
-        eval(self._body_code, copy(self._func.__globals__), cfg_locals)
+
+        with ConfigError.track(cfg_locals):
+            eval(self._body_code, copy(self._func.__globals__), cfg_locals)
 
         added = cfg_locals.revelation()
         config_summary = ConfigSummary(

--- a/sacred/utils.py
+++ b/sacred/utils.py
@@ -174,17 +174,16 @@ class ConfigError(SacredError):
 
     @classmethod
     @contextlib.contextmanager
-    def track(cls, wrapped):
+    def track(cls, config, prefix=None):
         try:
             yield
         except ConfigError as e:
             if not e.__prefix_handled__:
-                if wrapped.prefix:
+                if prefix:
                     e.__conflicting_configs__ = (
-                        join_paths(wrapped.prefix, str(c))
-                        for c in e.__conflicting_configs__
+                        join_paths(prefix, str(c)) for c in e.__conflicting_configs__
                     )
-                e.__config__ = wrapped.config
+                e.__config__ = config
                 e.__prefix_handled__ = True
             raise e
 


### PR DESCRIPTION
This PR adds tracking of the configuration also when a ConfigError is raised within a ConfigScope. Before, it would always print `None` for the conflicting config values.

Example:

```python
from sacred import Experiment
from sacred.utils import InvalidConfigError

ex = Experiment()

@ex.config
def config():
    a = 1
    raise InvalidConfigError('Invalid a', 'a')

@ex.automain
def main():
    pass
```

before:
```
sacred.utils.InvalidConfigError: Invalid a
Conflicting configuration values:
  a=None
```

now:
```
sacred.utils.InvalidConfigError: Invalid a
Conflicting configuration values:
  a=1
```