### PR TITLE
Handle tee_stdout.TimeoutExpired with warn() and terminate()

### DIFF
--- a/sacred/stdout_capturing.py
+++ b/sacred/stdout_capturing.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import subprocess
+import warnings
 from io import StringIO
 from contextlib import contextmanager
 import wrapt
@@ -172,8 +173,17 @@ def tee_output_fd():
             os.dup2(saved_stdout_fd, original_stdout_fd)
             os.dup2(saved_stderr_fd, original_stderr_fd)
 
-            tee_stdout.wait(timeout=1)
-            tee_stderr.wait(timeout=1)
+            try:
+                tee_stdout.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                warnings.warn("tee_stdout.wait timeout. Forcibly terminating.")
+                tee_stdout.terminate()
+
+            try:
+                tee_stderr.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                warnings.warn("tee_stderr.wait timeout. Forcibly terminating.")
+                tee_stderr.terminate()
 
             os.close(saved_stdout_fd)
             os.close(saved_stderr_fd)


### PR DESCRIPTION
When I run Sacred jobs in parallel using Ray I run into an error where the experiment first prints that it finished complete successfully, and then crashes with a unhandled `subprocess.TimeoutExpired` while waiting for `tee_stdout` to finish.

I don't know why this happens, but it seems like a pretty harmless solution to handle the exception, warn the user, and then `terminate` the tee subproc forcibly.

Closing the `tee` forcibly here could lead to some of the captured stdout not making it into Observers, but this is still better than the current behavior for `TimeoutExpired`, which is to simply exit on error and not `terminate`.

If it is helpful, then I can try to come up a minimal reproducible example of this error.