### PR TITLE
Use os.path.splitext() in render_template()

### DIFF
--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -224,7 +224,7 @@ class FileStorageObserver(RunObserver):
                 cout=self.cout,
                 savedir=self.dir,
             )
-            ext = self.template.suffix
+            _, ext = os.path.splitext(self.template)
             with open(os.path.join(self.dir, "report" + ext), "w") as f:
                 f.write(report)
 


### PR DESCRIPTION
When running this function on Python 3.8, I ran into an error of .suffix not being an available method of str. Changing to use this function should fix that error.