### PR TITLE
Fix mongo overwrite type

### DIFF
--- a/sacred/observers/mongo.py
+++ b/sacred/observers/mongo.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 import mimetypes
 import os.path
 import pickle
@@ -82,7 +82,7 @@ class MongoObserver(RunObserver):
         db_name: str = "sacred",
         collection: str = "runs",
         collection_prefix: str = "",
-        overwrite: Optional[bool] = None,
+        overwrite: Optional[Union[int, str]] = None,
         priority: int = DEFAULT_MONGO_PRIORITY,
         client: Optional["pymongo.MongoClient"] = None,
         failure_dir: Optional[PathType] = None,
@@ -620,7 +620,7 @@ class QueuedMongoObserver(QueueObserver):
         url: Optional[str] = None,
         db_name: str = "sacred",
         collection: str = "runs",
-        overwrite: Optional[bool] = None,
+        overwrite: Optional[Union[int, str]] = None,
         priority: int = DEFAULT_MONGO_PRIORITY,
         client: Optional["pymongo.MongoClient"] = None,
         **kwargs

--- a/sacred/observers/mongo.py
+++ b/sacred/observers/mongo.py
@@ -183,7 +183,7 @@ class MongoObserver(RunObserver):
         self.runs = runs_collection
         self.metrics = metrics_collection
         self.fs = fs
-        if isinstance(overwrite, (int, str)):
+        if overwrite is not None:
             overwrite = int(overwrite)
             run = self.runs.find_one({"_id": overwrite})
             if run is None:


### PR DESCRIPTION
The type hint for overwrite was `Optional[bool]` despite the [expected type](https://github.com/IDSIA/sacred/blob/4f968b6fb946dc716bc4abe0cbe80980f604554d/sacred/observers/mongo.py#L186) being `Optional[int or str]`. This fix updates the type hint and makes the parameter-set check less ambiguous.