### PR TITLE
Support config functions with trailing comma parameters

### DIFF
--- a/sacred/config/config_scope.py
+++ b/sacred/config/config_scope.py
@@ -93,7 +93,7 @@ def get_function_body(func):
     func_code_lines, start_idx = inspect.getsourcelines(func)
     func_code = "".join(func_code_lines)
     arg = "(?:[a-zA-Z_][a-zA-Z0-9_]*)"
-    arguments = r"{0}(?:\s*,\s*{0})*".format(arg)
+    arguments = r"{0}(?:\s*,\s*{0})*,?".format(arg)
     func_def = re.compile(
         r"^[ \t]*def[ \t]*{}[ \t]*\(\s*({})?\s*\)[ \t]*:[ \t]*(?:#[^\n]*)?\n".format(
             func.__name__, arguments


### PR DESCRIPTION
For config functions with large number of arguments, it is often necessary to format the arguments over multilines. In this case, it is common (and enforced by some code formatters, like `black`) that the last argument has a trailing comma. Minimal example:

```python3
#!/usr/bin/env python3

import sacred

ex = sacred.Experiment("test")

@ex.config
def default():
    x = 1
    y = 1

@ex.config
def f(
    x,
    y,
):
    z = x + y

@ex.automain
def main():
    pass
```

Running this in `master` sacred produces:
```bash
$ python3 test.py print_config
Traceback (most recent call last):
  File "test.py", line 12, in <module>
    @ex.config
  File "/home/adam/dev/sacred/sacred/ingredient.py", line 162, in config
    self.configurations.append(ConfigScope(function))
  File "/home/adam/dev/sacred/sacred/config/config_scope.py", line 25, in __init__
    self._body_code = get_function_body_code(func)
  File "/home/adam/dev/sacred/sacred/config/config_scope.py", line 146, in get_function_body_code
    func_body, line_offset = get_function_body(func)
  File "/home/adam/dev/sacred/sacred/config/config_scope.py", line 104, in get_function_body
    assert defs
AssertionError
```

With the changes in the PR, this produces expected behavior:

```bash
python3 test.py print_config
INFO - test - Running command 'print_config'
INFO - test - Started
Configuration (modified, added, typechanged, doc):
  seed = 505103377                   # the random seed for this experiment
  x = 1
  y = 1
  z = 2
INFO - test - Completed after 0:00:00
```