### PR TITLE
Raise an exception if an unknown setting is accessed

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ Mako
 MarkupSafe
 mock
 mongomock
-munch >= 2.5
+munch>=2.5
 packaging
 pandas
 pbr

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ Mako
 MarkupSafe
 mock
 mongomock
-munch
+munch >= 2.5
 packaging
 pandas
 pbr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 docopt>=0.3, <1.0
 jsonpickle>=1.2
-munch>=2.0.2, <3.0
+munch>=2.5, <3.0
 wrapt>=1.0, <2.0
 py-cpuinfo>=4.0
 colorama>=0.4

--- a/sacred/settings.py
+++ b/sacred/settings.py
@@ -3,10 +3,45 @@
 
 import platform
 import sacred.optional as opt
-from munch import munchify
+from munch import munchify, Munch
 from packaging import version
 
 __all__ = ("SETTINGS",)
+
+
+class FrozenKeyMunch(Munch):
+    __frozen_keys = False
+
+    def freeze_keys(self):
+        self.__frozen_keys = True
+        for v in self.values():
+            if isinstance(v, FrozenKeyMunch):
+                v.freeze_keys()
+
+    def _check_can_set(self, key, value, error_cls):
+        if not self.__frozen_keys:
+            # Anything is allowed before freezing
+            return
+
+        # Don't allow unknown keys
+        if key not in self:
+            raise error_cls(f"Unknown setting: {key}. Possible keys are: {self.keys()}")
+
+        # Don't allow setting keys that represent nested settings
+        if isinstance(self[key], Munch) and not isinstance(value, Munch):
+            # We don't want to overwrite a munch mapping
+            raise error_cls(
+                f'Can\'t set this setting ("{key}") to a scalar value '
+                f"{value}, it is a nested setting!"
+            )
+
+    def __setitem__(self, key, value):
+        self._check_can_set(key, value, KeyError)
+        super().__setitem__(key, value)
+
+    def __setattr__(self, key, value):
+        self._check_can_set(key, value, AttributeError)
+        super().__setattr__(key, value)
 
 
 SETTINGS = munchify(
@@ -27,8 +62,8 @@ SETTINGS = munchify(
             # function are replaced with a read-only container that raises an
             # Exception if it is attempted to write to those containers
             "READ_ONLY_CONFIG": True,
-            # regex patterns to filter out certain IDE or linter directives from
-            # inline comments in the documentation
+            # regex patterns to filter out certain IDE or linter directives
+            # from inline comments in the documentation
             "IGNORED_COMMENTS": ["^pylint:", "^noinspection"],
             # if true uses the numpy legacy API, i.e. _rnd in captured functions is
             # a numpy.random.RandomState rather than numpy.random.Generator.
@@ -45,9 +80,11 @@ SETTINGS = munchify(
             "CAPTURED_ENV": [],
         },
         "COMMAND_LINE": {
-            # disallow string fallback, if parsing a value from command-line failed
+            # disallow string fallback, if parsing a value from command-line
+            # failed
             "STRICT_PARSING": False,
-            # show command line options that are disabled (e.g. unmet dependencies)
+            # show command line options that are disabled (e.g. unmet
+            # dependencies)
             "SHOW_DISABLED_OPTIONS": True,
         },
         # configure how stdout/stderr are captured. ['no', 'sys', 'fd']
@@ -56,5 +93,7 @@ SETTINGS = munchify(
         "DISCOVER_DEPENDENCIES": "imported",
         # configure how source-files are discovered. [none, imported, sys, dir]
         "DISCOVER_SOURCES": "imported",
-    }
+    },
+    FrozenKeyMunch,
 )
+SETTINGS.freeze_keys()

--- a/sacred/settings.py
+++ b/sacred/settings.py
@@ -26,14 +26,18 @@ class FrozenKeyMunch(Munch):
 
         # Don't allow unknown keys
         if key not in self:
-            raise error_cls(f"Unknown setting: {key}. Possible keys are: {self.keys()}")
+            raise error_cls(
+                "Unknown setting: {key}. Possible keys are: {keys}".format(
+                    key=key, keys=list(self.keys())
+                )
+            )
 
         # Don't allow setting keys that represent nested settings
         if isinstance(self[key], Munch) and not isinstance(value, Mapping):
             # We don't want to overwrite a munch mapping
             raise error_cls(
-                f'Can\'t set this setting ("{key}") to a scalar value '
-                f"{value}, it is a nested setting!"
+                "Can't set this setting ({key}) to a scalar value "
+                "{value}, it is a nested setting!".format(key=key, value=value)
             )
 
     def __setitem__(self, key, value):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,37 @@
+import copy
+from sacred import SETTINGS as DEFAULT_SETTINGS
+
+import pytest
+
+
+def test_access_invalid_setting():
+    SETTINGS = copy.deepcopy(DEFAULT_SETTINGS)
+    with pytest.raises(AttributeError):
+        SETTINGS.INVALID_SETTING = "invalid"
+    with pytest.raises(KeyError):
+        SETTINGS["INVALID_SETTING"] = "invalid"
+
+
+def test_overwrite_collection():
+    SETTINGS = copy.deepcopy(DEFAULT_SETTINGS)
+    with pytest.raises(AttributeError):
+        SETTINGS.CONFIG = "invalid"
+    with pytest.raises(KeyError):
+        SETTINGS["CONFIG"] = "invalid"
+
+
+def test_partial_update():
+    # Setting a mapping should partially update
+    SETTINGS = copy.deepcopy(DEFAULT_SETTINGS)
+    keys = set(SETTINGS.CONFIG.keys())
+    SETTINGS.CONFIG = {"READ_ONLY_CONFIG": "somevalue"}
+    assert SETTINGS.CONFIG.READ_ONLY_CONFIG == "somevalue"
+
+    # All other config keys should still be there
+    assert keys == set(SETTINGS.CONFIG.keys())
+
+
+def test_access_valid_setting():
+    SETTINGS = copy.deepcopy(DEFAULT_SETTINGS)
+    SETTINGS.CONFIG.READ_ONLY_CONFIG = True
+    assert SETTINGS.CONFIG.READ_ONLY_CONFIG

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,32 +3,23 @@ from sacred import SETTINGS as DEFAULT_SETTINGS
 
 import pytest
 
+from sacred.settings import SettingError
+
 
 def test_access_invalid_setting():
     SETTINGS = copy.deepcopy(DEFAULT_SETTINGS)
-    with pytest.raises(AttributeError):
+    with pytest.raises(SettingError):
         SETTINGS.INVALID_SETTING = "invalid"
-    with pytest.raises(KeyError):
+    with pytest.raises(SettingError):
         SETTINGS["INVALID_SETTING"] = "invalid"
 
 
 def test_overwrite_collection():
     SETTINGS = copy.deepcopy(DEFAULT_SETTINGS)
-    with pytest.raises(AttributeError):
+    with pytest.raises(SettingError):
         SETTINGS.CONFIG = "invalid"
-    with pytest.raises(KeyError):
+    with pytest.raises(SettingError):
         SETTINGS["CONFIG"] = "invalid"
-
-
-def test_partial_update():
-    # Setting a mapping should partially update
-    SETTINGS = copy.deepcopy(DEFAULT_SETTINGS)
-    keys = set(SETTINGS.CONFIG.keys())
-    SETTINGS.CONFIG = {"READ_ONLY_CONFIG": "somevalue"}
-    assert SETTINGS.CONFIG.READ_ONLY_CONFIG == "somevalue"
-
-    # All other config keys should still be there
-    assert keys == set(SETTINGS.CONFIG.keys())
 
 
 def test_access_valid_setting():


### PR DESCRIPTION
This PR addresses #771 in that it freezes the settings structure and keys. It raises an exception if an unknown setting is accessed:

```python
from sacred import SETTINGS
SETTINGS.CONFIG.ASDF = 42
```
```
Traceback (most recent call last):
 ...
AttributeError: Unknown setting: ASDF. Possible keys are: dict_keys(['ENFORCE_KEYS_MONGO_COMPATIBLE', 'ENFORCE_KEYS_JSONPICKLE_COMPATIBLE', 'ENFORCE_VALID_PYTHON_IDENTIFIER_KEYS', 'ENFORCE_STRING_KEYS', 'ENFORCE_KEYS_NO_EQUALS', 'READ_ONLY_CONFIG', 'IGNORED_COMMENTS'])
```
Previously, it would just let the user set the invalid key.