### PR TITLE
fix: unicodeDecodeError when decoding nvidia-smi shell output bytes s…

### DIFF
--- a/sacred/host_info.py
+++ b/sacred/host_info.py
@@ -153,7 +153,7 @@ def _gpus():
         return
 
     try:
-        xml = subprocess.check_output(["nvidia-smi", "-q", "-x"]).decode()
+        xml = subprocess.check_output(["nvidia-smi", "-q", "-x"]).decode("utf-8", 'replace')
     except (FileNotFoundError, OSError, subprocess.CalledProcessError):
         raise IgnoreHostInfo()
 

--- a/sacred/host_info.py
+++ b/sacred/host_info.py
@@ -153,7 +153,9 @@ def _gpus():
         return
 
     try:
-        xml = subprocess.check_output(["nvidia-smi", "-q", "-x"]).decode("utf-8", 'replace')
+        xml = subprocess.check_output(["nvidia-smi", "-q", "-x"]).decode(
+            "utf-8", "replace"
+        )
     except (FileNotFoundError, OSError, subprocess.CalledProcessError):
         raise IgnoreHostInfo()
 


### PR DESCRIPTION
```shell
(venv)  python .\test_sacred.py
Exception originated from within Sacred.
Traceback (most recent calls):
  File "e:\github\sacred\sacred\host_info.py", line 156, in _gpus
    xml = subprocess.check_output(["nvidia-smi", "-q", "-x"]).decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb5 in position 11456: invalid start byte
```