### PR TITLE
Update jsonpickle version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docopt>=0.3, <1.0
-jsonpickle>=1.2, <2.0
+jsonpickle>=1.2
 munch>=2.0.2, <3.0
 wrapt>=1.0, <2.0
 py-cpuinfo>=4.0


### PR DESCRIPTION
Addresses #807. Removed requirement `jsonpickle <2.0`.