### PR TITLE
Fix an SQL observer bug

### DIFF
--- a/sacred/observers/sql.py
+++ b/sacred/observers/sql.py
@@ -79,23 +79,47 @@ class SqlObserver(RunObserver):
         Base.metadata.create_all(self.engine)
         sql_exp = Experiment.get_or_create(ex_info, self.session)
         sql_host = Host.get_or_create(host_info, self.session)
-        if _id is None:
-            i = self.session.query(Run).order_by(Run.id.desc()).first()
-            _id = 0 if i is None else i.id + 1
 
-        self.run = Run(
-            run_id=str(_id),
-            config=json.dumps(flatten(config)),
-            command=command,
-            priority=meta_info.get("priority", 0),
-            comment=meta_info.get("comment", ""),
-            experiment=sql_exp,
-            host=sql_host,
-            status=status,
-            **kwargs,
-        )
-        self.session.add(self.run)
-        self.save()
+        if _id is None:
+            while _id is None:
+                i = self.session.query(Run).order_by(Run.id.desc()).first()
+                _id = 0 if i is None else i.id + 1
+
+                self.run = Run(
+                    run_id=str(_id),
+                    config=json.dumps(flatten(config)),
+                    command=command,
+                    priority=meta_info.get("priority", 0),
+                    comment=meta_info.get("comment", ""),
+                    experiment=sql_exp,
+                    host=sql_host,
+                    status=status,
+                    **kwargs,
+                )
+                self.session.add(self.run)
+
+                with self.lock:
+                    try:
+                        self.session.commit()
+                        break
+                    except IntegrityError:
+                        self.session.rollback()
+                        _id = None
+        else:
+            self.run = Run(
+                run_id=str(_id),
+                config=json.dumps(flatten(config)),
+                command=command,
+                priority=meta_info.get("priority", 0),
+                comment=meta_info.get("comment", ""),
+                experiment=sql_exp,
+                host=sql_host,
+                status=status,
+                **kwargs,
+            )
+            self.session.add(self.run)
+            self.save()
+
         return _id or self.run.run_id
 
     def heartbeat_event(self, info, captured_out, beat_time, result):


### PR DESCRIPTION
**Description of the problem:**

When multiple experiments start within a second of each other, some experiments hang and are never added to the database due to a race condition - they try to use a run_id that is already used by another experiment. An excerpt of the error:

```
INFO - sqlalchemy.engine.base.Engine - ROLLBACK
ERROR - prepare_data - Failed after 0:00:00!
ERROR - prepare_data - Traceback (most recent call last):
  File "~/anaconda/envs/tf2-graphviz/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1283, in _execute_context
    self.dialect.do_execute(
  File "~/anaconda/envs/tf2-graphviz/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 590, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "run_run_id_key"
DETAIL:  Key (run_id)=(10838942) already exists.
```

**Solution this pull request implements:**

If a unique run_id hasn't been obtained previously, try adding the new experiment to the database until a successful commit. Query the database for the highest run_id already in the database each time.