### PR TITLE
Update TinyDbObserver

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -21,8 +21,8 @@ scandir==1.4
 sentinels==1.0.0
 smmap2==2.0.1
 SQLAlchemy>=1.3.0
-tinydb==3.2.1
-tinydb-serialization==1.0.3
+tinydb>=3.6
+tinydb-serialization>=2.0.0
 wrapt==1.10.8
 scikit-learn==0.20.3
 pymongo==3.9.0

--- a/sacred/observers/tinydb_hashfs/__init__.py
+++ b/sacred/observers/tinydb_hashfs/__init__.py
@@ -1,0 +1,3 @@
+from .tinydb_hashfs import TinyDbReader, TinyDbObserver, tiny_db_option
+
+__all__ = ["TinyDbObserver", "TinyDbReader", "tiny_db_option"]

--- a/sacred/observers/tinydb_hashfs/bases.py
+++ b/sacred/observers/tinydb_hashfs/bases.py
@@ -2,6 +2,8 @@ import datetime as dt
 import json
 import os
 from io import BufferedReader, FileIO
+from pathlib import Path
+from typing import Tuple
 
 from hashfs import HashFS
 from tinydb import TinyDB
@@ -98,8 +100,9 @@ class FileSerializer(Serializer):
         return file_reader
 
 
-def get_db_file_manager(root_dir):
-    fs = HashFS(os.path.join(root_dir, "hashfs"), depth=3, width=2, algorithm="md5")
+def get_db_file_manager(root_dir) -> Tuple[TinyDB, HashFS]:
+    root_dir = Path(root_dir)
+    fs = HashFS(root_dir / "hashfs", depth=3, width=2, algorithm="md5")
 
     # Setup Serialisation object for non list/dict objects
     serialization_store = SerializationMiddleware()

--- a/sacred/observers/tinydb_hashfs/tinydb_hashfs.py
+++ b/sacred/observers/tinydb_hashfs/tinydb_hashfs.py
@@ -28,7 +28,7 @@ class TinyDbObserver(RunObserver):
         return cls(path, overwrite)
 
     def __init__(self, path="./runs_db", overwrite=None):
-        from .tinydb_hashfs_bases import get_db_file_manager
+        from .bases import get_db_file_manager
 
         root_dir = os.path.abspath(path)
         os.makedirs(root_dir, exist_ok=True)
@@ -58,13 +58,13 @@ class TinyDbObserver(RunObserver):
     def save(self):
         """Insert or update the current run entry."""
         if self.db_run_id:
-            self.runs.update(self.run_entry, eids=[self.db_run_id])
+            self.runs.update(self.run_entry, doc_ids=[self.db_run_id])
         else:
             db_run_id = self.runs.insert(self.run_entry)
             self.db_run_id = db_run_id
 
     def save_sources(self, ex_info):
-        from .tinydb_hashfs_bases import BufferedReaderWrapper
+        from .bases import BufferedReaderWrapper
 
         source_info = []
         for source_name, md5 in ex_info["sources"]:
@@ -148,7 +148,7 @@ class TinyDbObserver(RunObserver):
         self.save()
 
     def resource_event(self, filename):
-        from .tinydb_hashfs_bases import BufferedReaderWrapper
+        from .bases import BufferedReaderWrapper
 
         id_ = self.fs.put(filename).id
         handle = BufferedReaderWrapper(open(filename, "rb"))
@@ -159,7 +159,7 @@ class TinyDbObserver(RunObserver):
             self.save()
 
     def artifact_event(self, name, filename, metadata=None, content_type=None):
-        from .tinydb_hashfs_bases import BufferedReaderWrapper
+        from .bases import BufferedReaderWrapper
 
         id_ = self.fs.put(filename).id
         handle = BufferedReaderWrapper(open(filename, "rb"))
@@ -187,7 +187,7 @@ def tiny_db_option(args, run):
 
 class TinyDbReader:
     def __init__(self, path):
-        from .tinydb_hashfs_bases import get_db_file_manager
+        from .bases import get_db_file_manager
 
         root_dir = os.path.abspath(path)
         if not os.path.exists(root_dir):
@@ -329,11 +329,9 @@ Outputs:
     def fetch_metadata(self, exp_name=None, query=None, indices=None):
         """Return all metadata for matching experiment name, index or query."""
         from tinydb import Query
-        from tinydb.queries import QueryImpl
 
         if exp_name or query:
             if query:
-                assert type(query), QueryImpl
                 q = query
             elif exp_name:
                 q = Query().experiment.name.search(exp_name)

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -64,7 +64,7 @@ def test_tinydb_observer_started_event_creates_run(tinydb_obs, sample_run):
     _id = tinydb_obs.started_event(**sample_run)
     assert _id is not None
     assert len(tinydb_obs.runs) == 1
-    db_run = tinydb_obs.runs.get(eid=1)
+    db_run = tinydb_obs.runs.get(doc_id=1)
     assert db_run == {
         "_id": _id,
         "experiment": sample_run["ex_info"],
@@ -87,7 +87,7 @@ def test_tinydb_observer_started_event_uses_given_id(tinydb_obs, sample_run):
     _id = tinydb_obs.started_event(**sample_run)
     assert _id == sample_run["_id"]
     assert len(tinydb_obs.runs) == 1
-    db_run = tinydb_obs.runs.get(eid=1)
+    db_run = tinydb_obs.runs.get(doc_id=1)
     assert db_run["_id"] == sample_run["_id"]
 
 
@@ -100,7 +100,7 @@ def test_tinydb_observer_started_event_saves_given_sources(tinydb_obs, sample_ru
 
     assert _id is not None
     assert len(tinydb_obs.runs) == 1
-    db_run = tinydb_obs.runs.get(eid=1)
+    db_run = tinydb_obs.runs.get(doc_id=1)
 
     # Check all but the experiment section
     db_run_copy = db_run.copy()
@@ -130,7 +130,7 @@ def test_tinydb_observer_started_event_saves_given_sources(tinydb_obs, sample_ru
     tinydb_obs.db_run_id = None
     tinydb_obs.started_event(**sample_run)
     assert len(tinydb_obs.runs) == 2
-    db_run2 = tinydb_obs.runs.get(eid=2)
+    db_run2 = tinydb_obs.runs.get(doc_id=2)
 
     assert (
         db_run["experiment"]["sources"][0][:2]
@@ -188,7 +188,7 @@ def test_tinydb_observer_heartbeat_event_updates_run(tinydb_obs, sample_run):
     tinydb_obs.heartbeat_event(info=info, captured_out=outp, beat_time=T2, result=42)
 
     assert len(tinydb_obs.runs) == 1
-    db_run = tinydb_obs.runs.get(eid=1)
+    db_run = tinydb_obs.runs.get(doc_id=1)
     assert db_run["heartbeat"] == T2
     assert db_run["result"] == 42
     assert db_run["info"] == info
@@ -201,7 +201,7 @@ def test_tinydb_observer_completed_event_updates_run(tinydb_obs, sample_run):
     tinydb_obs.completed_event(stop_time=T2, result=42)
 
     assert len(tinydb_obs.runs) == 1
-    db_run = tinydb_obs.runs.get(eid=1)
+    db_run = tinydb_obs.runs.get(doc_id=1)
     assert db_run["stop_time"] == T2
     assert db_run["result"] == 42
     assert db_run["status"] == "COMPLETED"
@@ -213,7 +213,7 @@ def test_tinydb_observer_interrupted_event_updates_run(tinydb_obs, sample_run):
     tinydb_obs.interrupted_event(interrupt_time=T2, status="INTERRUPTED")
 
     assert len(tinydb_obs.runs) == 1
-    db_run = tinydb_obs.runs.get(eid=1)
+    db_run = tinydb_obs.runs.get(doc_id=1)
     assert db_run["stop_time"] == T2
     assert db_run["status"] == "INTERRUPTED"
 
@@ -225,7 +225,7 @@ def test_tinydb_observer_failed_event_updates_run(tinydb_obs, sample_run):
     tinydb_obs.failed_event(fail_time=T2, fail_trace=fail_trace)
 
     assert len(tinydb_obs.runs) == 1
-    db_run = tinydb_obs.runs.get(eid=1)
+    db_run = tinydb_obs.runs.get(doc_id=1)
     assert db_run["stop_time"] == T2
     assert db_run["status"] == "FAILED"
     assert db_run["fail_trace"] == fail_trace
@@ -241,7 +241,7 @@ def test_tinydb_observer_artifact_event(tinydb_obs, sample_run):
 
     assert tinydb_obs.fs.exists(filename)
 
-    db_run = tinydb_obs.runs.get(eid=1)
+    db_run = tinydb_obs.runs.get(doc_id=1)
     assert db_run["artifacts"][0][0] == name
 
     with open(filename, "rb") as f:
@@ -259,7 +259,7 @@ def test_tinydb_observer_resource_event(tinydb_obs, sample_run):
 
     assert tinydb_obs.fs.exists(filename)
 
-    db_run = tinydb_obs.runs.get(eid=1)
+    db_run = tinydb_obs.runs.get(doc_id=1)
     assert db_run["resources"][0][:2] == [filename, md5]
 
     with open(filename, "rb") as f:
@@ -278,7 +278,7 @@ def test_tinydb_observer_resource_event_when_resource_present(tinydb_obs, sample
 
     tinydb_obs.resource_event(filename)
 
-    db_run = tinydb_obs.runs.get(eid=1)
+    db_run = tinydb_obs.runs.get(doc_id=1)
     assert db_run["resources"][0][:2] == [filename, md5]
 
 

--- a/tests/test_observers/test_tinydb_observer.py
+++ b/tests/test_observers/test_tinydb_observer.py
@@ -17,7 +17,7 @@ from hashfs import HashFS
 
 from sacred.dependencies import get_digest
 from sacred.observers.tinydb_hashfs import TinyDbObserver, tiny_db_option
-from sacred.observers.tinydb_hashfs_bases import BufferedReaderWrapper
+from sacred.observers.tinydb_hashfs.bases import BufferedReaderWrapper
 
 from sacred import optional as opt
 from sacred.experiment import Experiment
@@ -28,7 +28,7 @@ T2 = datetime.datetime(1999, 5, 5, 5, 5, 5, 5)
 
 @pytest.fixture()
 def tinydb_obs(tmpdir):
-    return TinyDbObserver.create(path=tmpdir.strpath)
+    return TinyDbObserver(path=tmpdir.strpath)
 
 
 @pytest.fixture()
@@ -309,7 +309,7 @@ def test_custom_bufferreaderwrapper(tmpdir):
 
 @pytest.mark.skipif(not opt.has_numpy, reason="needs numpy")
 def test_serialisation_of_numpy_ndarray(tmpdir):
-    from sacred.observers.tinydb_hashfs_bases import NdArraySerializer
+    from sacred.observers.tinydb_hashfs.bases import NdArraySerializer
     from tinydb_serialization import SerializationMiddleware
     import numpy as np
 
@@ -336,8 +336,8 @@ def test_serialisation_of_numpy_ndarray(tmpdir):
 
 @pytest.mark.skipif(not opt.has_pandas, reason="needs pandas")
 def test_serialisation_of_pandas_dataframe(tmpdir):
-    from sacred.observers.tinydb_hashfs_bases import DataFrameSerializer
-    from sacred.observers.tinydb_hashfs_bases import SeriesSerializer
+    from sacred.observers.tinydb_hashfs.bases import DataFrameSerializer
+    from sacred.observers.tinydb_hashfs.bases import SeriesSerializer
     from tinydb_serialization import SerializationMiddleware
 
     import numpy as np


### PR DESCRIPTION
Fixes: #816

- Update TinyDb Version to 3.6+
- Use document api instead of the old element api (this caused TinyDb to crash)
- Move all files related to TinyDb into their own sub-module (for better clarity)