### PR TITLE
Fix Numpy Type Deprecation (Issue #851), README Update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ and install it yourself:
 You might want to also install the ``numpy`` and the ``pymongo`` packages. They are
 optional dependencies but they offer some cool features:
 
-    pip install numpy, pymongo
+    pip install numpy pymongo
 
 Tests
 -----

--- a/sacred/config/custom_containers.py
+++ b/sacred/config/custom_containers.py
@@ -268,13 +268,12 @@ SIMPLIFY_TYPE = {
 if opt.has_numpy:
     from sacred.optional import np
 
-    NP_FLOATS = ["float", "float16", "float32", "float64", "float128"]
+    NP_FLOATS = ["float16", "float32", "float64", "float128"]
     for npf in NP_FLOATS:
         if hasattr(np, npf):
             SIMPLIFY_TYPE[getattr(np, npf)] = float
 
     NP_INTS = [
-        "int",
         "int8",
         "int16",
         "int32",


### PR DESCRIPTION
Fixes the following issue:
https://github.com/IDSIA/sacred/issues/851

Also updates `pip install` command in README to be valid, runnable command.

Note: I haven't been able to successfully run this projects tests on my laptop, so if someone is able to run tests on these changes locally, that would be much appreciated. I've created a separate issue documenting this problem:
https://github.com/IDSIA/sacred/issues/852