### PR TITLE
Remove numpy legacy random support.

### DIFF
--- a/sacred/randomness.py
+++ b/sacred/randomness.py
@@ -4,7 +4,6 @@
 import random
 
 import sacred.optional as opt
-from sacred.settings import SETTINGS
 from sacred.utils import module_is_in_cache
 
 SEEDRANGE = (1, int(1e9))
@@ -25,10 +24,7 @@ def create_rnd(seed):
         repr(seed), type(seed)
     )
     if opt.has_numpy:
-        if SETTINGS.CONFIG.NUMPY_RANDOM_LEGACY_API:
-            return opt.np.random.RandomState(seed)
-        else:
-            return opt.np.random.default_rng(seed)
+        return opt.np.random.default_rng(seed)
     else:
         return random.Random(seed)
 

--- a/sacred/settings.py
+++ b/sacred/settings.py
@@ -82,13 +82,6 @@ SETTINGS = FrozenKeyMunch.fromDict(
             # regex patterns to filter out certain IDE or linter directives
             # from inline comments in the documentation
             "IGNORED_COMMENTS": ["^pylint:", "^noinspection"],
-            # if true uses the numpy legacy API, i.e. _rnd in captured functions is
-            # a numpy.random.RandomState rather than numpy.random.Generator.
-            # numpy.random.RandomState became legacy with numpy v1.19.
-            "NUMPY_RANDOM_LEGACY_API": version.parse(opt.np.__version__)
-            < version.parse("1.19")
-            if opt.has_numpy
-            else False,
         },
         "HOST_INFO": {
             # Collect information about GPUs using the nvidia-smi tool


### PR DESCRIPTION
Numpy dropped support for [v1.19 on june 21st](https://numpy.org/neps/nep-0029-deprecation_policy.html). This removes the legacy randomness support for Numpy v1.19.