### PR TITLE
Add `pint.Qunatity` units support

### DIFF
--- a/docs/collected_information.rst
+++ b/docs/collected_information.rst
@@ -216,6 +216,9 @@ In any case, the numbers should form an increasing sequence.
             # Implicit step counter (0, 1, 2, 3, ...)
             # incremented with each call for training.accuracy:
             _run.log_scalar("training.accuracy", value * 2)
+            # Log an entry with units
+            ureg = pint.UnitRegistry()
+            _run.log_scalar("training.distance", value * 2 * ureg.meter)
             # Another option is to use the Experiment object (must be running)
             # The training.diff has its own step counter (0, 1, 2, ...) too
             ex.log_scalar("training.diff", value * 2)
@@ -249,7 +252,7 @@ the step number can be found in ``metric["steps"][i]`` and the time of the measu
     ``steps``           Array of steps (e.g. ``[0, 1, 2, 3, 4]``)
     ``values``          Array of measured values
     ``timestamps``      Array of times of capturing the individual measurements
-    ``units``           Base units of the measurement (or None)
+    ``units``           Units of the measurement (or None)
     ==================  =======================================================
 
 

--- a/docs/collected_information.rst
+++ b/docs/collected_information.rst
@@ -186,6 +186,7 @@ You might want to measure various values during your experiments, such as
 the progress of prediction accuracy over training steps.
 
 Sacred supports tracking of numerical series (e.g. int, float) using the Metrics API.
+If the value is a `pint.Quantity https://pint.readthedocs.io/en/stable/`_, the units will also be tracked.
 To access the API in experiments, the experiment must be running and the variable referencing the current experiment
 or run must be available in the scope. The ``_run.log_scalar(metric_name, value, step)`` method takes
 a metric name (e.g. "training.loss"), the measured value and the iteration step in which the value was taken.
@@ -220,7 +221,14 @@ In any case, the numbers should form an increasing sequence.
             ex.log_scalar("training.diff", value * 2)
 
 
-Currently, the information is collected only by two observers: the :ref:`mongo_observer` and the :ref:`file_observer`. For the Mongo Observer, metrics are stored in the ``metrics`` collection of MongoDB and are identified by their name (e.g. "training.loss") and the experiment run id they belong to. For the :ref:`file_observer`, metrics are stored in the file ``metrics.json`` in the run id's directory and are organized by metric name (e.g. "training.loss").
+Currently, the information is collected only by the following observers:
+
+* :ref:`mongo_observer`
+    * Metrics are stored in the ``metrics`` collection of MongoDB and are identified by their name (e.g. "training.loss") and the experiment run id they belong to.
+* :ref:`file_observer`
+    * metrics are stored in the file ``metrics.json`` in the run id's directory and are organized by metric name (e.g. "training.loss").
+* :ref:`google_cloud_storage_observer`
+* :ref:`s3_observer`
 
 
 Metrics Records
@@ -238,9 +246,10 @@ the step number can be found in ``metric["steps"][i]`` and the time of the measu
     ``_id``             Unique identifier
     ``name``            The name of the metric (e.g. training.loss)
     ``run_id``          The identifier of the run (``_id`` in the runs collection)
-    ``steps``               Array of steps (e.g. ``[0, 1, 2, 3, 4]``)
-    ``values``               Array of measured values
+    ``steps``           Array of steps (e.g. ``[0, 1, 2, 3, 4]``)
+    ``values``          Array of measured values
     ``timestamps``      Array of times of capturing the individual measurements
+    ``units``           Base units of the measurement (or None)
     ==================  =======================================================
 
 

--- a/docs/observers.rst
+++ b/docs/observers.rst
@@ -651,6 +651,8 @@ created in ascending order, and each run directory will contain the files specif
 FileStorageObserver Directory Structure documentation above.
 
 
+.. _google_cloud_storage_observer:
+
 Google Cloud Storage Observer
 ============
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ py-cpuinfo>=4.0
 colorama>=0.4
 packaging>=18.0
 GitPython
+pint>=0.10

--- a/sacred/commandline_options.py
+++ b/sacred/commandline_options.py
@@ -4,17 +4,20 @@ Provides the basis for all command-line options (flags) in sacred.
 It defines the base class CommandLineOption and the standard supported flags.
 Some further options that add observers to the run are defined alongside those.
 """
+from __future__ import annotations
 
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 import inspect
 import re
 
-from sacred.run import Run
 from sacred.commands import print_config
 from sacred.utils import convert_camel_case_to_snake_case
 
 
-CLIFunction = Callable[[str, Run], None]
+if TYPE_CHECKING:
+    from sacred.run import Run
+
+    CLIFunction = Callable[[str, Run], None]
 
 
 class CLIOption:

--- a/sacred/config/captured_function.py
+++ b/sacred/config/captured_function.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 # coding=utf-8
+from __future__ import annotations
 
+from logging import Logger
 import time
 from datetime import timedelta
+from typing import TYPE_CHECKING, Any, Callable
 
 import wrapt
 from sacred.config.custom_containers import fallback_dict
@@ -10,8 +13,23 @@ from sacred.config.signature import Signature
 from sacred.randomness import create_rnd, get_seed
 from sacred.utils import ConfigError
 
+if TYPE_CHECKING:
+    from sacred.run import Run
 
-def create_captured_function(function, prefix=None):
+
+class CapturedFunction(Callable[..., Any]):
+    signature: Signature
+    uses_randomness: bool
+    logger: Logger
+    config: dict
+    rnd: Any
+    run: Run
+    prefix: Any
+
+
+def create_captured_function(
+    function: Callable[..., Any], prefix=None
+) -> CapturedFunction:
     sig = Signature(function)
     function.signature = sig
     function.uses_randomness = "_seed" in sig.arguments or "_rnd" in sig.arguments

--- a/sacred/initialize.py
+++ b/sacred/initialize.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 # coding=utf-8
+from __future__ import annotations
 
 import os
 from collections import OrderedDict, defaultdict
 from copy import copy, deepcopy
+from typing import TYPE_CHECKING, Any, Callable
 
 from sacred.config import (
     ConfigDict,
@@ -12,6 +14,8 @@ from sacred.config import (
     load_config_file,
     undogmatize,
 )
+from sacred.config.captured_function import CapturedFunction
+from sacred.config.config_scope import ConfigScope
 from sacred.config.config_summary import ConfigSummary
 from sacred.config.custom_containers import make_read_only
 from sacred.host_info import get_host_info
@@ -33,15 +37,19 @@ from sacred.utils import (
 )
 from sacred.settings import SETTINGS
 
+if TYPE_CHECKING:
+    from sacred.experiment import Experiment
+    from sacred.ingredient import Ingredient
+
 
 class Scaffold:
     def __init__(
         self,
-        config_scopes,
+        config_scopes: list[ConfigScope],
         subrunners,
         path,
         captured_functions,
-        commands,
+        commands: OrderedDict[str, Callable[..., Any]],
         named_configs,
         config_hooks,
         generate_seed,
@@ -283,8 +291,10 @@ def initialize_logging(experiment, scaffolding, log_level=None):
     return root_logger, root_logger.getChild(experiment.path)
 
 
-def create_scaffolding(experiment, sorted_ingredients):
-    scaffolding = OrderedDict()
+def create_scaffolding(
+    experiment: Experiment, sorted_ingredients: list[Ingredient]
+) -> OrderedDict[Ingredient, Scaffold]:
+    scaffolding: OrderedDict[Ingredient, Scaffold] = OrderedDict()
     for ingredient in sorted_ingredients[:-1]:
         scaffolding[ingredient] = Scaffold(
             config_scopes=ingredient.configurations,
@@ -336,7 +346,9 @@ def get_config_modifications(scaffolding):
     return config_modifications
 
 
-def get_command(scaffolding, command_path):
+def get_command(
+    scaffolding: OrderedDict[Ingredient, Scaffold], command_path: str
+) -> CapturedFunction:
     path, _, command_name = command_path.rpartition(".")
     if path not in scaffolding:
         raise KeyError('Ingredient for command "%s" not found.' % command_path)
@@ -392,13 +404,13 @@ def get_scaffolding_and_config_name(named_config, scaffolding):
 
 
 def create_run(
-    experiment,
-    command_name,
+    experiment: Experiment,
+    command_name: str,
     config_updates=None,
     named_configs=(),
     force=False,
     log_level=None,
-):
+) -> Run:
 
     sorted_ingredients = gather_ingredients_topological(experiment)
     scaffolding = create_scaffolding(experiment, sorted_ingredients)

--- a/sacred/metrics_logger.py
+++ b/sacred/metrics_logger.py
@@ -158,7 +158,7 @@ def linearize_value(
         return value, None
     if expected_units is not None:
         value = value.to(expected_units)
-    return value.magnitude, value.units
+    return value.magnitude, str(value.units)
 
 
 class MetricLinearizationError(Exception):

--- a/sacred/observers/base.py
+++ b/sacred/observers/base.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python
 # coding=utf-8
+from __future__ import annotations
+from typing import Any
+
 
 __all__ = ("RunObserver", "td_format")
+
+
+from datetime import datetime, timedelta
+from sacred.config.captured_function import CapturedFunction
+
+from sacred.config.config_dict import ConfigDict
 
 
 class RunObserver:
@@ -10,34 +19,52 @@ class RunObserver:
     priority = 0
 
     def queued_event(
-        self, ex_info, command, host_info, queue_time, config, meta_info, _id
+        self,
+        ex_info: dict,
+        command: CapturedFunction,
+        host_info: dict,
+        queue_time: datetime,
+        config: ConfigDict,
+        meta_info: dict,
+        _id,
     ):
         pass
 
     def started_event(
-        self, ex_info, command, host_info, start_time, config, meta_info, _id
+        self,
+        ex_info: dict,
+        command: CapturedFunction,
+        host_info: dict,
+        start_time: datetime,
+        config: ConfigDict,
+        meta_info: dict,
+        _id,
     ):
         pass
 
-    def heartbeat_event(self, info, captured_out, beat_time, result):
+    def heartbeat_event(
+        self, info: dict, captured_out: str, beat_time: datetime, result: Any | None
+    ):
         pass
 
-    def completed_event(self, stop_time, result):
+    def completed_event(self, stop_time: datetime, result: Any | None):
         pass
 
-    def interrupted_event(self, interrupt_time, status):
+    def interrupted_event(self, interrupt_time: datetime, status: str):
         pass
 
-    def failed_event(self, fail_time, fail_trace):
+    def failed_event(self, fail_time: datetime, fail_trace: str):
         pass
 
-    def resource_event(self, filename):
+    def resource_event(self, filename: str):
         pass
 
-    def artifact_event(self, name, filename, metadata=None, content_type=None):
+    def artifact_event(
+        self, name: str, filename: str, metadata: dict = None, content_type: str = None
+    ):
         pass
 
-    def log_metrics(self, metrics_by_name, info):
+    def log_metrics(self, metrics_by_name: dict[str, dict[str, list]], info: dict):
         pass
 
     def join(self):
@@ -45,7 +72,7 @@ class RunObserver:
 
 
 # http://stackoverflow.com/questions/538666/python-format-timedelta-to-string
-def td_format(td_object):
+def td_format(td_object: timedelta):
     seconds = int(td_object.total_seconds())
     if seconds == 0:
         return "less than a second"

--- a/sacred/observers/file_storage.py
+++ b/sacred/observers/file_storage.py
@@ -315,6 +315,7 @@ class FileStorageObserver(RunObserver):
                     "values": [],
                     "steps": [],
                     "timestamps": [],
+                    "units": None,
                 }
 
             saved_metrics[metric_name]["values"] += metric_ptr["values"]
@@ -324,6 +325,7 @@ class FileStorageObserver(RunObserver):
             # when we're trying to convert into json.
             timestamps_norm = [ts.isoformat() for ts in metric_ptr["timestamps"]]
             saved_metrics[metric_name]["timestamps"] += timestamps_norm
+            saved_metrics[metric_name]["units"] = metric_ptr["units"]
 
         self.save_json(saved_metrics, "metrics.json")
 

--- a/sacred/observers/gcs_observer.py
+++ b/sacred/observers/gcs_observer.py
@@ -312,6 +312,7 @@ class GoogleCloudStorageObserver(RunObserver):
                     "values": [],
                     "steps": [],
                     "timestamps": [],
+                    "units": None,
                 }
 
             self.saved_metrics[metric_name]["values"] += metric_ptr["values"]
@@ -319,6 +320,7 @@ class GoogleCloudStorageObserver(RunObserver):
 
             timestamps_norm = [ts.isoformat() for ts in metric_ptr["timestamps"]]
             self.saved_metrics[metric_name]["timestamps"] += timestamps_norm
+            self.saved_metrics[metric_name]["units"] = metric_ptr["units"]
 
         self.save_json(self.saved_metrics, "metrics.json")
 

--- a/sacred/observers/mongo.py
+++ b/sacred/observers/mongo.py
@@ -344,7 +344,7 @@ class MongoObserver(RunObserver):
                 "values": {"$each": metrics_by_name[key]["values"]},
                 "timestamps": {"$each": metrics_by_name[key]["timestamps"]},
             }
-            update = {"$push": push}
+            update = {"$push": push, "$set": {"units": metrics_by_name[key]["units"]}}
             result = self.metrics.update_one(query, update, upsert=True)
             if result.upserted_id is not None:
                 # This is the first time we are storing this metric
@@ -549,7 +549,7 @@ class QueueCompatibleMongoObserver(MongoObserver):
             "values": {"$each": metrics_values["values"]},
             "timestamps": {"$each": metrics_values["timestamps"]},
         }
-        update = {"$push": push}
+        update = {"$push": push, "$set": {"units": metrics_values["units"]}}
         result = self.metrics.update_one(query, update, upsert=True)
         if result.upserted_id is not None:
             # This is the first time we are storing this metric

--- a/sacred/observers/s3_observer.py
+++ b/sacred/observers/s3_observer.py
@@ -340,6 +340,7 @@ class S3Observer(RunObserver):
                     "values": [],
                     "steps": [],
                     "timestamps": [],
+                    "units": None,
                 }
 
             self.saved_metrics[metric_name]["values"] += metric_ptr["values"]
@@ -347,6 +348,7 @@ class S3Observer(RunObserver):
 
             timestamps_norm = [ts.isoformat() for ts in metric_ptr["timestamps"]]
             self.saved_metrics[metric_name]["timestamps"] += timestamps_norm
+            self.saved_metrics[metric_name]["units"] = metric_ptr["units"]
 
         self.save_json(self.saved_metrics, "metrics.json")
 

--- a/sacred/run.py
+++ b/sacred/run.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python
 # coding=utf-8
+from __future__ import annotations
 
 import datetime
+import logging
 import os.path
 import sys
 import traceback as tb
+from typing import Any, Callable
 
 from sacred import metrics_logger
+from sacred.config.captured_function import CapturedFunction
 from sacred.metrics_logger import linearize_metrics
 from sacred.randomness import set_global_seed
 from sacred.utils import SacredInterrupt, join_paths, IntervalTimer
 from sacred.stdout_capturing import get_stdcapturer
+from sacred.observers import RunObserver
+from sacred.config import ConfigDict
 
 
 class Run:
@@ -18,16 +24,16 @@ class Run:
 
     def __init__(
         self,
-        config,
+        config: ConfigDict,
         config_modifications,
-        main_function,
-        observers,
-        root_logger,
-        run_logger,
-        experiment_info,
-        host_info,
-        pre_run_hooks,
-        post_run_hooks,
+        main_function: CapturedFunction,
+        observers: list[RunObserver],
+        root_logger: logging.Logger,
+        run_logger: logging.Logger,
+        experiment_info: dict,
+        host_info: dict,
+        pre_run_hooks: list[Callable[[], Any]],
+        post_run_hooks: list[Callable[[], Any]],
         captured_out_filter=None,
     ):
 


### PR DESCRIPTION
Adds a `units` field to `linearize_metrics` output per discussion in #880.

I took a slightly different approach. Instead of adding `units` to `ScalarMetricLogEntry`, I added "units" to the linearized output and filled it in based on whether or not `value` is of type `pint.Quantity`. Not sure if it would be better to add `units=None` to `log_scalar_metric` and do the `pint` support in the background, or to do it as I've done. On the one hand, it would remove the hard dependency on `pint` and would be a little easier for users. On the other hand, users wouldn't have full access to `pint`s features, so they couldn't define their own units.

I went ahead and added in the unit conversion as `pint` makes it quite easy to do. Units will be converted to the unit of the first log entry. If the units cannot be converted, a custom exception is raised. If you submit some entries with units and some without, it assumes that the entries without units use the same units as the entries with units. Might be better to throw an exception there as a user really shouldn't be doing that.

While working on this feature, I added some type hints where they were missing. Not my finest type hints, but it's better than nothing!

I have an update adding metric support (with units) to `SqlObserver` ready, but it relies on this PR.