### PR TITLE
FIXED: CPU shows UNKNOWN

### DIFF
--- a/sacred/host_info.py
+++ b/sacred/host_info.py
@@ -207,4 +207,4 @@ def _get_cpu_by_proc_cpuinfo():
 
 
 def _get_cpu_by_pycpuinfo():
-    return cpuinfo.get_cpu_info().get("brand", "Unknown")
+    return cpuinfo.get_cpu_info().get("brand_raw", "Unknown")


### PR DESCRIPTION
Function get_cpu_info() in Package cpuinfo returns a dict that CPU model is indexed by "brand_raw" instead of "brand", see L210 in sacred/hostinfo.py .