### PR TITLE
Add HOST_INFO.INCLUDE_CPU_INFO setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -46,6 +46,9 @@ Here is a brief list of all currently available options.
   * ``INCLUDE_GPU_INFO`` *(default: True)*
     Try to collect information about GPUs using the nvidia-smi tool.
     Deactivating this can cut the start-up time of a Sacred run by about 1 sec.
+  * ``INCLUDE_CPU_INFO`` *(default: True)*
+    Try to collect information about the CPU using py-cpuinfo.
+    Deactivating this can cut the start-up time of a Sacred run by about 3 sec.
   * ``CAPTURED_ENV`` *(default: [])*
     List of ENVIRONMENT variable names to store in the host-info.
 

--- a/sacred/host_info.py
+++ b/sacred/host_info.py
@@ -135,6 +135,9 @@ def _python_version():
 
 @host_info_gatherer(name="cpu")
 def _cpu():
+    if not SETTINGS.HOST_INFO.INCLUDE_CPU_INFO:
+        return
+
     if platform.system() == "Windows":
         return _get_cpu_by_pycpuinfo()
     try:

--- a/sacred/settings.py
+++ b/sacred/settings.py
@@ -93,6 +93,8 @@ SETTINGS = FrozenKeyMunch.fromDict(
         "HOST_INFO": {
             # Collect information about GPUs using the nvidia-smi tool
             "INCLUDE_GPU_INFO": True,
+            # Collect information about CPUs using py-cpuinfo
+            "INCLUDE_CPU_INFO": True,
             # List of ENVIRONMENT variables to store in host-info
             "CAPTURED_ENV": [],
         },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,5 +105,6 @@ def tmpfile():
     os.remove(f.name)
 
 
-# Deactivate GPU info to speed up tests
+# Deactivate GPU and CPU info to speed up tests
 SETTINGS.HOST_INFO.INCLUDE_GPU_INFO = False
+SETTINGS.HOST_INFO.INCLUDE_CPU_INFO = False

--- a/tests/test_host_info.py
+++ b/tests/test_host_info.py
@@ -6,10 +6,13 @@ import pytest
 from sacred.host_info import get_host_info, host_info_getter, host_info_gatherers
 
 
-def test_get_host_info():
-    host_info = get_host_info()
+def test_get_host_info(monkeypatch: pytest.MonkeyPatch):
+    with monkeypatch.context() as cntx:
+        cntx.setattr("sacred.settings.SETTINGS.HOST_INFO.INCLUDE_CPU_INFO", True)
+        host_info = get_host_info()
     assert isinstance(host_info["hostname"], str)
     assert isinstance(host_info["cpu"], str)
+    assert host_info["cpu"] != "Unknown"
     assert isinstance(host_info["os"], (tuple, list))
     assert isinstance(host_info["python_version"], str)
 


### PR DESCRIPTION
On my machine, py-cpuinfo is quite slow. Seems it's a known issue: https://github.com/workhorsy/py-cpuinfo/issues/155

This setting cuts the time it takes me to run the test suite in half.