### PR TITLE
Fix dependencies notebook script

### DIFF
--- a/sacred/dependencies.py
+++ b/sacred/dependencies.py
@@ -377,7 +377,7 @@ $
 
 def get_py_file_if_possible(pyc_name):
     """Try to retrieve a X.py file for a given X.py[c] file."""
-    if pyc_name.endswith((".py", ".so", ".pyd")):
+    if pyc_name.endswith((".py", ".so", ".pyd", ".ipynb")):
         return pyc_name
     assert pyc_name.endswith(".pyc")
     non_compiled_file = pyc_name[:-1]


### PR DESCRIPTION
A quick fix for #893. Fixes #893.

There are other things in `dependencies.py` that could need some improvement, but that requires some more thought.