### PR TITLE
Fix CLI option doc

### DIFF
--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -529,7 +529,7 @@ Beat Interval
 +-----------------------------------------+-----------------------------------------------+
 | ``-b BEAT_INTERVAL``                    |  set the interval between heartbeat events    |
 +-----------------------------------------+                                               |
-| ``--beat_interval=BEAT_INTERVAL``       |                                               |
+| ``--beat-interval=BEAT_INTERVAL``       |                                               |
 +-----------------------------------------+-----------------------------------------------+
 
 A running experiment regularly fires a :ref:`heartbeat` event to synchronize


### PR DESCRIPTION
The beat interval CLI option is beat-interval (dash), not beat_interval (underscore)