### PR TITLE
Update requirements: jsonpickle version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docopt>=0.3, <1.0
-jsonpickle>=1.2
+jsonpickle>=2.2.0
 munch>=2.5, <3.0
 wrapt>=1.0, <2.0
 py-cpuinfo>=4.0


### PR DESCRIPTION
The changes made in #902 require jsonpickle to have at least version 2.2.0 (`on_missing` parameter of `jsonpickle.decode`)