### PR TITLE
Lift upper bound for munch to < 4.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 docopt>=0.3, <1.0
 jsonpickle>=2.2.0
-munch>=2.5, <3.0
+munch>=2.5, <4.0
 wrapt>=1.0, <2.0
 py-cpuinfo>=4.0
 colorama>=0.4


### PR DESCRIPTION
now that munch 3.0 has been released, there should be no compatibility issue.
Rationale: munch 3.0 reduces import times which are important for applications that utilize `argcomplete` and `munch` (like `seml`).