### PR TITLE
fix import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 docopt>=0.3, <1.0
 jsonpickle>=2.2.0
-munch>=2.5, <4.0
+munch>=2.5, <5.0
 wrapt>=1.0, <2.0
 py-cpuinfo>=4.0
 colorama>=0.4

--- a/sacred/optional.py
+++ b/sacred/optional.py
@@ -41,7 +41,7 @@ except ImportError:
 else:
     try:
         libc = ctypes.cdll.msvcrt  # Windows
-    except OSError:
+    except (OSError, AttributeError):
         libc = ctypes.cdll.LoadLibrary(find_library("c"))
 
 


### PR DESCRIPTION
The conda forge package update fails due to an error with the libc import. I guess this should fix the issue. Here's the log for reference:
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=814073&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=986b1512-c876-5f92-0d81-ba851554a0a3