### PR TITLE
switch from docopt to docopt-ng

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 pytest==7.1.2 # tests/test_utils.py depends on that pytest version is exactly 7.1.2
 colorama
-docopt
+docopt-ng
 gitdb2
 GitPython
 hashfs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docopt>=0.3, <1.0
+docopt-ng>=0.9, <1.0
 jsonpickle>=2.2.0
 munch>=2.5, <5.0
 wrapt>=1.0, <2.0

--- a/sacred/arg_parser.py
+++ b/sacred/arg_parser.py
@@ -9,6 +9,7 @@ first programmatically generate a usage text and then parse it with ``docopt``.
 import ast
 import textwrap
 import inspect
+import re
 from shlex import quote
 
 from sacred.serializer import restore
@@ -197,6 +198,12 @@ def format_usage(program_name, description, commands=None, options=()):
         commands=_format_command_usage(commands),
     )
     return usage
+
+
+def printable_usage(doc):
+    # in python < 2.7 you can't pass flags=re.IGNORECASE
+    usage_split = re.split(r"([Uu][Ss][Aa][Gg][Ee]:)", doc)
+    return re.split(r"\n\s*\n", "".join(usage_split[1:]))[0].strip()
 
 
 def _get_first_line_of_docstring(func):

--- a/sacred/experiment.py
+++ b/sacred/experiment.py
@@ -1,4 +1,5 @@
 """The Experiment class, which is central to sacred."""
+
 import inspect
 import os.path
 import sys
@@ -6,10 +7,10 @@ import warnings
 from collections import OrderedDict
 from typing import Sequence, Optional, List
 
-from docopt import docopt, printable_usage
+from docopt import docopt
 
 from sacred import SETTINGS
-from sacred.arg_parser import format_usage, get_config_updates
+from sacred.arg_parser import get_config_updates, format_usage, printable_usage
 from sacred import commandline_options
 from sacred.commandline_options import CLIOption
 from sacred.commands import (
@@ -294,7 +295,7 @@ class Experiment(Ingredient):
         """
         argv = ensure_wellformed_argv(argv)
         short_usage, usage, internal_usage = self.get_usage()
-        args = docopt(internal_usage, [str(a) for a in argv[1:]], help=False)
+        args = docopt(internal_usage, [str(a) for a in argv[1:]], default_help=False)
 
         cmd_name = args.get("COMMAND") or self.default_command
         config_updates, named_configs = get_config_updates(args["UPDATE"])

--- a/tests/test_arg_parser.py
+++ b/tests/test_arg_parser.py
@@ -51,8 +51,8 @@ def test_parse_individual_arguments(argv, expected):
     options = gather_command_line_options()
     usage = format_usage("test.py", "", {}, options)
     argv = shlex.split(argv)
-    plain = docopt(usage, [], help=False)
-    args = docopt(usage, argv, help=False)
+    plain = docopt(usage, [], default_help=False)
+    args = docopt(usage, argv, default_help=False)
     plain.update(expected)
     assert args == plain
 

--- a/tests/test_observers/test_s3_observer.py
+++ b/tests/test_observers/test_s3_observer.py
@@ -77,7 +77,7 @@ def _get_file_data(bucket_name, key):
     return s3.Object(bucket_name, key).get()["Body"].read()
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_fs_observer_started_event_creates_bucket(observer, sample_run):
     _id = observer.started_event(**sample_run)
     run_dir = s3_join(BASEDIR, str(_id))
@@ -102,7 +102,7 @@ def test_fs_observer_started_event_creates_bucket(observer, sample_run):
     }
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_fs_observer_started_event_increments_run_id(observer, sample_run):
     _id = observer.started_event(**sample_run)
     _id2 = observer.started_event(**sample_run)
@@ -119,7 +119,7 @@ def test_s3_observer_equality():
     assert obs_one != different_bucket
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_raises_error_on_duplicate_id_directory(observer, sample_run):
     observer.started_event(**sample_run)
     sample_run["_id"] = 1
@@ -127,7 +127,7 @@ def test_raises_error_on_duplicate_id_directory(observer, sample_run):
         observer.started_event(**sample_run)
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_completed_event_updates_run_json(observer, sample_run):
     observer.started_event(**sample_run)
     run = json.loads(
@@ -145,7 +145,7 @@ def test_completed_event_updates_run_json(observer, sample_run):
     assert run["status"] == "COMPLETED"
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_interrupted_event_updates_run_json(observer, sample_run):
     observer.started_event(**sample_run)
     run = json.loads(
@@ -163,7 +163,7 @@ def test_interrupted_event_updates_run_json(observer, sample_run):
     assert run["status"] == "SERVER_EXPLODED"
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_failed_event_updates_run_json(observer, sample_run):
     observer.started_event(**sample_run)
     run = json.loads(
@@ -181,7 +181,7 @@ def test_failed_event_updates_run_json(observer, sample_run):
     assert run["status"] == "FAILED"
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_queued_event_updates_run_json(observer, sample_run):
     del sample_run["start_time"]
     sample_run["queue_time"] = T2
@@ -194,7 +194,7 @@ def test_queued_event_updates_run_json(observer, sample_run):
     assert run["status"] == "QUEUED"
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_artifact_event_works(observer, sample_run, tmpfile):
     observer.started_event(**sample_run)
     observer.artifact_event("test_artifact.py", tmpfile.name)


### PR DESCRIPTION
Since docopt is deprecated and hasn't been updated in 10 years, its regex is throwing errors in Python >3.12. This PR changes the dependency from docopt to [docopt-ng](https://github.com/jazzband/docopt-ng), which is a maintained fork of docopt.

I also changed some unittests to work again. However, the unittests do not properly support numpy 2.0. To get them to run successfully, one has to install `numpy<2.0`.

In general, sacred could use some cleaning as it heavily relies on deprecated packages like `pkgutil` and `pkg_resources`. Another example is `datetime.datetime.utcnow()` which is now `datetime.datetime.now(datetime.UTC)`.