### PR TITLE
Pin mongomock

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -24,7 +24,7 @@ tinydb
 tinydb-serialization
 wrapt
 scikit-learn
-pymongo
+pymongo<4.9 # mongomock.gridfs.enable_gridfs_integration() is not compatible with pymongo>=4.9. https://github.com/mongomock/mongomock/issues/903
 py-cpuinfo
 boto3
 moto

--- a/tests/test_observers/test_queue_mongo_observer.py
+++ b/tests/test_observers/test_queue_mongo_observer.py
@@ -1,15 +1,6 @@
 import datetime
-from sacred.observers.queue import QueueObserver
 import mock
 import pytest
-import sys
-
-if sys.version_info >= (3, 10):
-    pytest.skip(
-        "Skip pymongo tests for Python 3.10 because mongomock doesn't "
-        "support Python 3.10",
-        allow_module_level=True,
-    )
 
 from sacred.metrics_logger import ScalarMetricLogEntry, linearize_metrics
 
@@ -25,7 +16,6 @@ from sacred.dependencies import get_digest
 from sacred.observers.mongo import (
     QueuedMongoObserver,
     MongoObserver,
-    QueueCompatibleMongoObserver,
 )
 from .failing_mongo_mock import ReconnectingMongoClient
 


### PR DESCRIPTION
Fixes the failing tests in #933 by using a pymongo version <4.9 until the issue in mongomock is fixed.