### PR TITLE
Introducing Sacred Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Sacred
 
 |pypi| |py_versions| |license| |rtfd| |doi|
 
-|build| |coverage| |code_quality| |black| |gurubase|
+|build| |coverage| |code_quality| |black|
 
 
 
@@ -70,7 +70,7 @@ Example
 
 Documentation
 -------------
-The documentation is hosted at `ReadTheDocs <http://sacred.readthedocs.org/>`_.
+The documentation is hosted at `ReadTheDocs <http://sacred.readthedocs.org/>`_. You can also [Ask Sacred Guru](https://gurubase.io/g/sacred), it is an Sacred-focused AI to answer your questions.
 
 Installing
 ----------
@@ -272,7 +272,3 @@ in Proceedings of the 15th Python in Science Conference (SciPy 2017), Austin, Te
 .. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/ambv/black
     :alt: Code style: black
-
-.. |gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20Sacred%20Guru-006BFF
-    :target: https://gurubase.io/g/sacred
-    :alt: Sacred Guru on Gurubase

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Sacred
 
 |pypi| |py_versions| |license| |rtfd| |doi|
 
-|build| |coverage| |code_quality| |black|
+|build| |coverage| |code_quality| |black| |gurubase|
 
 
 
@@ -272,3 +272,7 @@ in Proceedings of the 15th Python in Science Conference (SciPy 2017), Austin, Te
 .. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/ambv/black
     :alt: Code style: black
+
+.. |gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20Sacred%20Guru-006BFF
+    :target: https://gurubase.io/g/sacred
+    :alt: Sacred Guru on Gurubase

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ Example
 
 Documentation
 -------------
-The documentation is hosted at `ReadTheDocs <http://sacred.readthedocs.org/>`_. You can also `Ask Sacred Guru <https://gurubase.io/g/sacred>`_, it is an Sacred-focused AI to answer your questions.
+The documentation is hosted at `ReadTheDocs <http://sacred.readthedocs.org/>`_. You can also `Ask Sacred Guru <https://gurubase.io/g/sacred>`_, it is a Sacred-focused AI to answer your questions.
 
 Installing
 ----------

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ Example
 
 Documentation
 -------------
-The documentation is hosted at `ReadTheDocs <http://sacred.readthedocs.org/>`_. You can also [Ask Sacred Guru](https://gurubase.io/g/sacred), it is an Sacred-focused AI to answer your questions.
+The documentation is hosted at `ReadTheDocs <http://sacred.readthedocs.org/>`_. You can also `Ask Sacred Guru <https://gurubase.io/g/sacred>`_, it is an Sacred-focused AI to answer your questions.
 
 Installing
 ----------


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Sacred Guru](https://gurubase.io/g/sacred) to Gurubase. Sacred Guru uses the data from this repo and data from the [docs](https://sacred.readthedocs.io/en/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Sacred Guru" badge, which highlights that Sacred now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Sacred Guru in Gurubase, just let me know that's totally fine.
