### PR TITLE
Add QUEUED state to SQL Run base

### DIFF
--- a/sacred/observers/sql_bases.py
+++ b/sacred/observers/sql_bases.py
@@ -281,6 +281,7 @@ class Run(Base):
             "INTERRUPTED",
             "TIMEOUT",
             "FAILED",
+            "QUEUED",
             name="status_enum",
         )
     )

--- a/tests/test_observers/test_sql_observer.py
+++ b/tests/test_observers/test_sql_observer.py
@@ -143,6 +143,15 @@ def test_sql_observer_heartbeat_event_updates_run(sql_obs, sample_run, session):
     assert db_run.captured_out == outp
 
 
+def test_sql_observer_queued_event(sql_obs, sample_run, session):
+    sample_run["queue_time"] = sample_run.pop("start_time")
+    sql_obs.queued_event(**sample_run)
+
+    assert session.query(Run).count() == 1
+    db_run = session.query(Run).first()
+    assert db_run.status == "QUEUED"
+
+
 def test_sql_observer_completed_event_updates_run(sql_obs, sample_run, session):
     sql_obs.started_event(**sample_run)
     sql_obs.completed_event(stop_time=T2, result=42)


### PR DESCRIPTION
Adds QUEUED state to the SQL definition so that `python experiment.py -q` works with an SQL observer.

Fixes #940 